### PR TITLE
ci: set up assign reviewers github action

### DIFF
--- a/.github/reviewer-lottery.yml
+++ b/.github/reviewer-lottery.yml
@@ -1,0 +1,10 @@
+groups:
+  - name: devs
+    reviewers: 2
+    usernames:
+      - beforeAW
+      - dcbwe
+      - ell-ska
+      - DavidDyberg
+      - ADchasacademy
+      - Jelena8206

--- a/.github/workflows/assign-reviewers.yml
+++ b/.github/workflows/assign-reviewers.yml
@@ -3,7 +3,7 @@ on:
     types: [opened, ready_for_review, reopened]
 
 jobs:
-  test:
+  assign_reviewers:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v1

--- a/.github/workflows/assign-reviewers.yml
+++ b/.github/workflows/assign-reviewers.yml
@@ -1,7 +1,5 @@
-name: reviewer lottery
-
 on:
-  pull_request_target:
+  pull_request:
     types: [opened, ready_for_review, reopened]
 
 jobs:
@@ -11,4 +9,4 @@ jobs:
       - uses: actions/checkout@v1
       - uses: uesteibar/reviewer-lottery@v3
         with:
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          repo-token: ${{ secrets.PERSONAL_ACCESS_TOKEN }}

--- a/.github/workflows/assign-reviewers.yml
+++ b/.github/workflows/assign-reviewers.yml
@@ -1,0 +1,14 @@
+name: reviewer lottery
+
+on:
+  pull_request_target:
+    types: [opened, ready_for_review, reopened]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v1
+      - uses: uesteibar/reviewer-lottery@v3
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
closes #11 

sets up a github action to run and assign two random people for review. i had to use a personal access token since we can't change permissions of this repository