### PR TITLE
feat: poster component

### DIFF
--- a/resources/views/components/poster.blade.php
+++ b/resources/views/components/poster.blade.php
@@ -1,0 +1,5 @@
+@props(['rounded' => true])
+
+<img
+    {{ $attributes->class(['rounded-xs' => $rounded, 'aspect-2/3 object-cover']) }}
+/>

--- a/resources/views/components/poster.blade.php
+++ b/resources/views/components/poster.blade.php
@@ -1,5 +1,13 @@
 @props(['rounded' => true])
 
-<img
-    {{ $attributes->class(['rounded-xs' => $rounded, 'aspect-2/3 object-cover']) }}
-/>
+@if (! $attributes->get('src'))
+    <div
+        {{ $attributes->class(['rounded-xs' => $rounded, 'flex aspect-2/3 items-center justify-center bg-slate-700']) }}
+    >
+        <x-lucide-clapperboard class="size-6 text-slate-500" />
+    </div>
+@else
+    <img
+        {{ $attributes->class(['rounded-xs' => $rounded, 'aspect-2/3 object-cover']) }}
+    />
+@endif


### PR DESCRIPTION
closes #52 

- creates a poster component that will be rounded by default but it can be turned of (for the list component)
- it will always keep the correct aspect ratio and make sure the image isn't stretched weirdly if it doesn't fit

example usage:
```php
<x-poster
    src="https://m.media-amazon.com/images/M/MV5BZGEyYzBiYmItZDM4OC00NTdmLWJlYzctODdiM2E2MjZmYTU2XkEyXkFqcGc@._V1_FMjpg_UX1000_.jpg"
    class="max-w-sm"
/>
```

<img width="1552" alt="image" src="https://github.com/user-attachments/assets/7b30930c-03c0-4dbe-9be1-05524f6ff660" />

if no source is given it will show a placeholder (eg in empty lists):
<img width="115" alt="image" src="https://github.com/user-attachments/assets/b36e81cd-3974-4a4f-8748-6d45ee7a398b" />