### PR TITLE
feat: create rating component

### DIFF
--- a/resources/views/components/rating.blade.php
+++ b/resources/views/components/rating.blade.php
@@ -1,0 +1,33 @@
+@props([
+    'rating',
+    'size',
+    'bold' => false,
+])
+
+<div
+    @class([
+        'flex items-center',
+        'gap-0.5' => $size === 'sm',
+        'gap-1' => $size === 'md' || $size === 'lg',
+    ])
+>
+    <span
+        @class([
+            'text-indigo-200',
+            'text-xs' => $size === 'sm',
+            'text-base' => $size === 'md',
+            'text-lg' => $size === 'lg',
+            'font-bold' => $bold,
+        ])
+    >
+        {{ $rating }}
+    </span>
+    <x-lucide-star
+        @class([
+            'text-indigo-400 *:fill-current',
+            'size-3' => $size === 'sm',
+            'size-4' => $size === 'md',
+            'size-6' => $size === 'lg',
+        ])
+    />
+</div>


### PR DESCRIPTION
closes #56 

- supports 3 sizes
- takes in a dynamic rating
- can be bold or not

example usage:
```php
<x-rating rating="5.6" size="sm" />
<x-rating rating="8" size="md" />
<x-rating rating="9.3" size="lg" bold />
```

<img width="97" alt="image" src="https://github.com/user-attachments/assets/f5264154-79f4-4469-88db-8ef544681df2" />