### PR TITLE
feat: create button component

### DIFF
--- a/resources/css/app.css
+++ b/resources/css/app.css
@@ -5,3 +5,14 @@
 @theme {
   --font-primary: 'Outfit', sans-serif;
 }
+
+@layer base {
+  * {
+    @apply outline-offset-1 outline-indigo-300;
+  }
+
+  *:focus,
+  *:focus-visible {
+    @apply outline-1;
+  }
+}

--- a/resources/views/components/button.blade.php
+++ b/resources/views/components/button.blade.php
@@ -1,0 +1,20 @@
+@props(['variant' => 'primary', 'size' => 'md', 'type' => 'button'])
+
+@php
+    $classes = [
+        'rounded-full bg-indigo-400 text-slate-50 hover:bg-indigo-500' => $variant === 'primary',
+        'rounded-full border-2 border-slate-100 text-slate-100 hover:border-indigo-400 hover:text-indigo-400' => $variant === 'secondary',
+        'rounded-sm bg-transparent p-1 hover:bg-slate-700' => $variant === 'icon',
+        'px-6 py-2 text-base' => $size === 'md' && $variant !== 'icon',
+        'px-3 py-1 text-xs' => $size === 'sm' && $variant !== 'icon',
+        'inline-flex cursor-pointer items-center justify-center font-bold whitespace-nowrap transition',
+    ];
+@endphp
+
+@if ($type === 'button')
+    <button {{ $attributes->class($classes) }}>
+        {{ $slot }}
+    </button>
+@elseif ($type === 'link')
+    <a {{ $attributes->class($classes) }}>{{ $slot }}</a>
+@endif

--- a/resources/views/components/button.blade.php
+++ b/resources/views/components/button.blade.php
@@ -1,6 +1,10 @@
-@props(['variant' => 'primary', 'size' => 'md', 'type' => 'button'])
+@props(['variant' => 'primary', 'size' => 'md', 'type' => 'button', 'srLabel' => null])
 
 @php
+    if ($variant === 'icon' && ! isset($srLabel)) {
+        throw new Exception('an icon button must have a screen reader label');
+    }
+
     $classes = [
         'rounded-full bg-indigo-400 text-slate-50 hover:bg-indigo-500' => $variant === 'primary',
         'rounded-full border-2 border-slate-100 text-slate-100 hover:border-indigo-400 hover:text-indigo-400' => $variant === 'secondary',
@@ -13,8 +17,22 @@
 
 @if ($type === 'button')
     <button {{ $attributes->class($classes) }}>
+        @isset($srLabel)
+            <span class="sr-only">
+                {{ $srLabel }}
+            </span>
+        @endisset
+
         {{ $slot }}
     </button>
 @elseif ($type === 'link')
-    <a {{ $attributes->class($classes) }}>{{ $slot }}</a>
+    <a {{ $attributes->class($classes) }}>
+        @isset($srLabel)
+            <span class="sr-only">
+                {{ $srLabel }}
+            </span>
+        @endisset
+
+        {{ $slot }}
+    </a>
 @endif


### PR DESCRIPTION
closes #51 

- 3 variants
- 2 sizes
- can be either a button (with `onclick`) or link (with `href`)
- icon variants must provide a label for screen readers
- add focus outlines for accessibility

example usage:
```blade
<x-button>Click me</x-button>
<x-button size="sm">Click me</x-button>
<x-button variant="secondary">Click me</x-button>
<x-button variant="secondary" size="sm">Click me</x-button>
<x-button variant="icon" srLabel="Click me">
    <x-lucide-x class="size-4" />
</x-button>
```

https://github.com/user-attachments/assets/7addaef0-52d4-4869-b752-cb474656ea57

_note: the cursor is a pointer, it's just when i screen record it's not picking up_