### PR TITLE
feat: create search component

### DIFF
--- a/resources/views/components/search.blade.php
+++ b/resources/views/components/search.blade.php
@@ -1,0 +1,36 @@
+@props([
+    'placeholder',
+])
+
+<div
+    class="flex max-w-xs items-center gap-1 rounded-full bg-slate-700 px-4 py-2"
+    x-data="{
+        search: '',
+        clear() {
+            this.search = ''
+        },
+    }"
+>
+    <label for="{{ $attributes->get('id') }}">
+        <span class="sr-only">Search</span>
+        <x-lucide-search class="size-4 text-slate-50" />
+    </label>
+
+    <input
+        x-model="search"
+        type="text"
+        id="{{ $attributes->get('id') }}"
+        name="search"
+        placeholder="{{ $placeholder }}"
+        class="flex-1 rounded-xs px-1 text-slate-50 placeholder:text-slate-400"
+    />
+
+    <x-button
+        variant="icon"
+        srLabel="Clear search"
+        x-show="search.length > 0"
+        @click="clear()"
+    >
+        <x-lucide-x class="size-4 text-slate-400" />
+    </x-button>
+</div>


### PR DESCRIPTION
closes #66 

- clears the input when clicking the x button with alpine.js

**example usage:**
```blade
<x-search placeholder="Search..." id="search" />
```

https://github.com/user-attachments/assets/a19baec8-4d96-4ac3-b766-f460c0d36b95

_note:_ we will need to make adjustments to the behavior of the x button. we sometimes use it to close out of the entire search bar in the design. but i think this is out of scope for this issue and i'll create a new one