### PR TITLE
feat: create avatar component

### DIFF
--- a/resources/views/components/avatar.blade.php
+++ b/resources/views/components/avatar.blade.php
@@ -1,0 +1,22 @@
+@props([
+    'size',
+    'image' => null,
+])
+
+@php
+    $sizes = [
+        'size-6' => $size === 'sm',
+        'size-12' => $size === 'md',
+        'size-28' => $size === 'lg',
+    ];
+@endphp
+
+@if (isset($image))
+    <img
+        src="{{ $image }}"
+        @class(array_merge($sizes, ['rounded-full border-1 border-slate-50 object-cover']))
+        {{ $attributes }}
+    />
+@else
+    <x-lucide-circle-user-round @class($sizes) />
+@endif


### PR DESCRIPTION
closes #68 

- has 3 sizes
- optionally takes an image

**example usage:**
```blade
<x-avatar size="md" />
<x-avatar
    size="md"
    image="https://images.unsplash.com/photo-1..."
    alt="usernames avatar"
/>
```

<img width="76" alt="image" src="https://github.com/user-attachments/assets/38bf2539-656e-411f-9a95-298a5a729168" />