### PR TITLE
Fix: Prevent Duplicate Movie Entries in a List

### DIFF
--- a/app/Models/Movie.php
+++ b/app/Models/Movie.php
@@ -4,14 +4,18 @@ namespace App\Models;
 
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
-use Illuminate\Database\Eloquent\Relations\HasMany;
+use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 
 class Movie extends Model
 {
+<<<<<<< HEAD
     use HasFactory;
 
     public function lists(): HasMany
+=======
+    public function lists(): BelongsToMany
+>>>>>>> 8c03deb (fix: add composite key to list_movie table)
     {
-        return $this->hasMany(Movie::class);
+        return $this->belongsToMany(MovieList::class, 'list_movie', 'movie_id', 'list_id');
     }
 }

--- a/app/Models/Movie.php
+++ b/app/Models/Movie.php
@@ -2,19 +2,12 @@
 
 namespace App\Models;
 
-use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 
 class Movie extends Model
 {
-<<<<<<< HEAD
-    use HasFactory;
-
-    public function lists(): HasMany
-=======
     public function lists(): BelongsToMany
->>>>>>> 8c03deb (fix: add composite key to list_movie table)
     {
         return $this->belongsToMany(MovieList::class, 'list_movie', 'movie_id', 'list_id');
     }

--- a/app/Models/MovieList.php
+++ b/app/Models/MovieList.php
@@ -14,6 +14,6 @@ class MovieList extends Model
 
     public function movies(): BelongsToMany
     {
-        return $this->belongsToMany(MovieList::class, 'list_id');
+        return $this->belongsToMany(Movie::class, 'list_movie', 'list_id', 'movie_id');
     }
 }

--- a/database/migrations/2025_01_29_224410_create_list_movie_table.php
+++ b/database/migrations/2025_01_29_224410_create_list_movie_table.php
@@ -15,8 +15,9 @@ class CreateListMovieTable extends Migration
     {
         Schema::create('list_movie', function (Blueprint $table) {
             $table->id();
-            $table->foreignIdfor(MovieList::class, 'list_id')->constrained()->onDelete('cascade');
-            $table->foreignIdfor(Movie::class)->constrained()->onDelete('cascade');
+            $table->foreignIdFor(MovieList::class, 'list_id')->constrained()->onDelete('cascade');
+            $table->foreignIdFor(Movie::class)->constrained()->onDelete('cascade');
+            $table->unique(['list_id', 'movie_id']); // Composite unique key to prevent duplicates
             $table->timestamps();
         });
     }


### PR DESCRIPTION
# Fix: Prevent Duplicate Movie Entries in a List

## Summary
This update introduces a **composite unique key** on the `list_id` and `movie_id` columns to ensure that the same movie cannot be added multiple times to the same list.

## Change Details
The following constraint has been added in the migration:

```php
$table->unique(['list_id', 'movie_id']);
```

### Why This Fix?
Without this constraint, duplicate movie entries could be inserted into the same list, leading to data inconsistencies and incorrect application behavior. By enforcing this rule at the database level, we reduce the need for additional validation in the application code.

## Impact & Considerations
With this constraint in place, any attempt to insert a duplicate entry will result in an **SQL integrity constraint violation error**. To handle this properly, future code should:

- **Catch the database error** and return a user-friendly message.
- [**Validate uniqueness at the application level** before inserting data. ](https://stackoverflow.com/questions/23968415/laravel-eloquent-attach-vs-sync)

This ensures a smooth user experience while maintaining proper data integrity.

---

✅ **This fix prevents duplicate movie entries and ensures consistency in the database.**




closes #44 