### PR TITLE
feat: Add many to many relationship between Genre and Movie

### DIFF
--- a/app/Models/Genre.php
+++ b/app/Models/Genre.php
@@ -4,10 +4,16 @@ namespace App\Models;
 
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 
 class Genre extends Model
 {
     use HasFactory;
 
     protected $fillable = ['name'];
+
+    public function movies(): BelongsToMany
+    {
+        return $this->belongsToMany(Movie::class, 'genre_movie', 'genre_id', 'movie_id');
+    }
 }

--- a/app/Models/Genre.php
+++ b/app/Models/Genre.php
@@ -14,6 +14,7 @@ class Genre extends Model
 
     public function movies(): BelongsToMany
     {
-        return $this->belongsToMany(Movie::class, 'genre_movie', 'genre_id', 'movie_id');
+        return $this->belongsToMany(Movie::class, 'genre_movie', 'genre_id', 'movie_id')
+            ->withTimestamps();
     }
 }

--- a/app/Models/Movie.php
+++ b/app/Models/Movie.php
@@ -4,9 +4,13 @@ namespace App\Models;
 
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsToMany;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
 
 class Movie extends Model
 {
+
+    use HasFactory;
+
     public function lists(): BelongsToMany
     {
         return $this->belongsToMany(MovieList::class, 'list_movie', 'movie_id', 'list_id')

--- a/app/Models/Movie.php
+++ b/app/Models/Movie.php
@@ -9,11 +9,13 @@ class Movie extends Model
 {
     public function lists(): BelongsToMany
     {
-        return $this->belongsToMany(MovieList::class, 'list_movie', 'movie_id', 'list_id');
+        return $this->belongsToMany(MovieList::class, 'list_movie', 'movie_id', 'list_id')
+            ->withTimestamps();
     }
 
     public function genres(): BelongsToMany
     {
-        return $this->belongsToMany(Genre::class, 'genre_movie', 'movie_id', 'genre_id');
+        return $this->belongsToMany(Genre::class, 'genre_movie', 'movie_id', 'genre_id')
+            ->withTimestamps();
     }
 }

--- a/app/Models/Movie.php
+++ b/app/Models/Movie.php
@@ -11,4 +11,9 @@ class Movie extends Model
     {
         return $this->belongsToMany(MovieList::class, 'list_movie', 'movie_id', 'list_id');
     }
+
+    public function genres(): BelongsToMany
+    {
+        return $this->belongsToMany(Genre::class, 'genre_movie', 'movie_id', 'genre_id');
+    }
 }

--- a/app/Models/Movie.php
+++ b/app/Models/Movie.php
@@ -2,13 +2,12 @@
 
 namespace App\Models;
 
+use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsToMany;
-use Illuminate\Database\Eloquent\Factories\HasFactory;
 
 class Movie extends Model
 {
-
     use HasFactory;
 
     public function lists(): BelongsToMany

--- a/app/Models/MovieList.php
+++ b/app/Models/MovieList.php
@@ -5,7 +5,6 @@ namespace App\Models;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsToMany;
-use Illuminate\Database\Eloquent\Factories\HasFactory;
 
 class MovieList extends Model
 {

--- a/app/Models/MovieList.php
+++ b/app/Models/MovieList.php
@@ -5,6 +5,7 @@ namespace App\Models;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsToMany;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
 
 class MovieList extends Model
 {

--- a/database/migrations/2025_01_31_152355_create_genre_movie_table.php
+++ b/database/migrations/2025_01_31_152355_create_genre_movie_table.php
@@ -1,7 +1,7 @@
 <?php
 
-use App\Models\Movie;
 use App\Models\Genre;
+use App\Models\Movie;
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;

--- a/database/migrations/2025_01_31_152355_create_genre_movie_table.php
+++ b/database/migrations/2025_01_31_152355_create_genre_movie_table.php
@@ -1,0 +1,33 @@
+<?php
+
+use App\Models\Movie;
+use App\Models\Genre;
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('genre_movie', function (Blueprint $table) {
+
+            $table->id();
+            $table->foreignIdFor(Movie::class)->constrained()->onDelete('cascade');
+            $table->foreignIdFor(Genre::class)->constrained()->onDelete('cascade');
+            $table->unique(['movie_id', 'genre_id']); // Composite unique key to prevent duplicates
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('genre_movie');
+    }
+};


### PR DESCRIPTION
## New Feature: Many-to-Many Relationship Between Movies and Genres

This update introduces a pivot table to establish a **many-to-many** relationship between movies and genres. To ensure data integrity, a composite unique key has been added to prevent duplicate entries for the same movie-genre pair.

### Change Details
The following constraint has been added in the migration:

```php
$table->unique(['movie_id', 'genre_id']); 
```

### Why This Feature?
A movie can belong to multiple genres, and a genre can be associated with multiple movies. Using a **pivot table** allows efficient handling of this relationship while preventing redundant entries. The composite unique key ensures that each movie-genre combination is stored only once, avoiding duplicate associations.

### Impact & Considerations
With this constraint in place:

- Any attempt to insert a duplicate movie-genre entry will result in an SQL integrity constraint violation error.  
- Application logic should validate uniqueness before inserting data to avoid errors and improve user experience.  

By enforcing uniqueness at the database level, we ensure **data consistency** while simplifying application logic.

✅ This feature enables a structured **many-to-many relationship** between movies and genres while preventing duplicate associations.



closes #45 