### PR TITLE
feat: input label

### DIFF
--- a/resources/views/components/input/label.blade.php
+++ b/resources/views/components/input/label.blade.php
@@ -1,0 +1,7 @@
+@props([
+    'for',
+])
+
+<label for="{{ $for }}" class="px-2 text-base font-bold text-slate-100">
+    {{ $slot }}
+</label>


### PR DESCRIPTION
closes #207 

- simple label for our inputs
- scoped it under `/input` for organization purposes

### example usage
```blade
<x-input.label for="my-input">label</x-input.label>
```

![image](https://github.com/user-attachments/assets/efe3aec2-7dc3-4d62-8f1e-76b6211c12f0)