### PR TITLE
feat: text input

### DIFF
--- a/resources/views/components/input/text.blade.php
+++ b/resources/views/components/input/text.blade.php
@@ -1,0 +1,15 @@
+@props([
+    'name',
+    'placeholder',
+])
+
+<div {{ $attributes->class('flex flex-col gap-1') }}>
+    <x-input.label for="{{ $name }}">test</x-input.label>
+    <input
+        type="text"
+        id="{{ $name }}"
+        name="{{ $name }}"
+        placeholder="{{ $placeholder }}"
+        class="rounded-full bg-slate-700 px-4 py-2 text-base text-slate-50 placeholder:text-slate-400"
+    />
+</div>


### PR DESCRIPTION
closes #208

### example usage
```blade
<x-input.text class="w-80" name="my-text-input" placeholder="Placeholder" />
```

![image](https://github.com/user-attachments/assets/55d7e9a7-f485-4766-b396-2697f9550d08)