### PR TITLE
refactor: connect routes to controllers

### DIFF
--- a/app/Http/Controllers/Auth/AuthenticatedSessionController.php
+++ b/app/Http/Controllers/Auth/AuthenticatedSessionController.php
@@ -16,7 +16,7 @@ class AuthenticatedSessionController extends Controller
      */
     public function create(): View
     {
-        return view('auth.login');
+        return view('auth.log-in');
     }
 
     /**
@@ -28,7 +28,7 @@ class AuthenticatedSessionController extends Controller
 
         $request->session()->regenerate();
 
-        return redirect()->intended(route('dashboard', absolute: false));
+        return redirect()->intended(route('home', absolute: false));
     }
 
     /**

--- a/app/Http/Controllers/Auth/RegisteredUserController.php
+++ b/app/Http/Controllers/Auth/RegisteredUserController.php
@@ -19,7 +19,7 @@ class RegisteredUserController extends Controller
      */
     public function create(): View
     {
-        return view('auth.register');
+        return view('auth.sign-up');
     }
 
     /**

--- a/app/Http/Controllers/ListController.php
+++ b/app/Http/Controllers/ListController.php
@@ -12,7 +12,7 @@ class ListController extends Controller
      */
     public function index()
     {
-        //
+        return view('lists');
     }
 
     /**
@@ -36,7 +36,7 @@ class ListController extends Controller
      */
     public function show(MovieList $list)
     {
-        //
+        return view('movie-list');
     }
 
     /**

--- a/app/Http/Controllers/MovieController.php
+++ b/app/Http/Controllers/MovieController.php
@@ -12,7 +12,7 @@ class MovieController extends Controller
      */
     public function index()
     {
-        //
+        return view('home');
     }
 
     /**
@@ -20,7 +20,7 @@ class MovieController extends Controller
      */
     public function create()
     {
-        //
+        return view('admin.create-movie');
     }
 
     /**
@@ -34,15 +34,15 @@ class MovieController extends Controller
     /**
      * Display the specified resource.
      */
-    public function show(Movie $list)
+    public function show(Movie $movie)
     {
-        //
+        return view('movie');
     }
 
     /**
      * Show the form for editing the specified resource.
      */
-    public function edit(Movie $list)
+    public function edit(Movie $movie)
     {
         //
     }
@@ -50,7 +50,7 @@ class MovieController extends Controller
     /**
      * Update the specified resource in storage.
      */
-    public function update(Request $request, Movie $list)
+    public function update(Request $request, Movie $movie)
     {
         //
     }
@@ -58,7 +58,7 @@ class MovieController extends Controller
     /**
      * Remove the specified resource from storage.
      */
-    public function destroy(Movie $list)
+    public function destroy(Movie $movie)
     {
         //
     }

--- a/app/Http/Controllers/ProfileController.php
+++ b/app/Http/Controllers/ProfileController.php
@@ -12,6 +12,14 @@ use Illuminate\View\View;
 class ProfileController extends Controller
 {
     /**
+     * Display the specified resource.
+     */
+    public function show()
+    {
+        return view('profile');
+    }
+
+    /**
      * Display the user's profile form.
      */
     public function edit(Request $request): View

--- a/app/Http/Controllers/ReviewController.php
+++ b/app/Http/Controllers/ReviewController.php
@@ -12,7 +12,7 @@ class ReviewController extends Controller
      */
     public function index()
     {
-        //
+        return view('reviews');
     }
 
     /**
@@ -36,7 +36,7 @@ class ReviewController extends Controller
      */
     public function show(Review $review)
     {
-        //
+        return view('review');
     }
 
     /**

--- a/routes/auth.php
+++ b/routes/auth.php
@@ -1,59 +1,59 @@
 <?php
 
 use App\Http\Controllers\Auth\AuthenticatedSessionController;
-use App\Http\Controllers\Auth\ConfirmablePasswordController;
-use App\Http\Controllers\Auth\EmailVerificationNotificationController;
-use App\Http\Controllers\Auth\EmailVerificationPromptController;
-use App\Http\Controllers\Auth\NewPasswordController;
-use App\Http\Controllers\Auth\PasswordController;
-use App\Http\Controllers\Auth\PasswordResetLinkController;
+// use App\Http\Controllers\Auth\ConfirmablePasswordController;
+// use App\Http\Controllers\Auth\EmailVerificationNotificationController;
+// use App\Http\Controllers\Auth\EmailVerificationPromptController;
+// use App\Http\Controllers\Auth\NewPasswordController;
+// use App\Http\Controllers\Auth\PasswordController;
+// use App\Http\Controllers\Auth\PasswordResetLinkController;
 use App\Http\Controllers\Auth\RegisteredUserController;
-use App\Http\Controllers\Auth\VerifyEmailController;
+// use App\Http\Controllers\Auth\VerifyEmailController;
 use Illuminate\Support\Facades\Route;
 
 Route::middleware('guest')->group(function () {
-    Route::get('register', [RegisteredUserController::class, 'create'])
-        ->name('register');
+    Route::controller(RegisteredUserController::class)->group(function () {
+        Route::get('/sign-up', 'create')->name('sign-up');
+        Route::post('/sign-up', 'store');
+    });
 
-    Route::post('register', [RegisteredUserController::class, 'store']);
+    Route::controller(AuthenticatedSessionController::class)->group(function () {
+        Route::get('/log-in', 'create')->name('login');
+        Route::post('/log-in', 'store');
+    });
 
-    Route::get('login', [AuthenticatedSessionController::class, 'create'])
-        ->name('login');
+    // Route::get('forgot-password', [PasswordResetLinkController::class, 'create'])
+    //     ->name('password.request');
 
-    Route::post('login', [AuthenticatedSessionController::class, 'store']);
+    // Route::post('forgot-password', [PasswordResetLinkController::class, 'store'])
+    //     ->name('password.email');
 
-    Route::get('forgot-password', [PasswordResetLinkController::class, 'create'])
-        ->name('password.request');
+    // Route::get('reset-password/{token}', [NewPasswordController::class, 'create'])
+    //     ->name('password.reset');
 
-    Route::post('forgot-password', [PasswordResetLinkController::class, 'store'])
-        ->name('password.email');
-
-    Route::get('reset-password/{token}', [NewPasswordController::class, 'create'])
-        ->name('password.reset');
-
-    Route::post('reset-password', [NewPasswordController::class, 'store'])
-        ->name('password.store');
+    // Route::post('reset-password', [NewPasswordController::class, 'store'])
+    //     ->name('password.store');
 });
 
-Route::middleware('auth')->group(function () {
-    Route::get('verify-email', EmailVerificationPromptController::class)
-        ->name('verification.notice');
+// Route::middleware('auth')->group(function () {
+//     Route::get('verify-email', EmailVerificationPromptController::class)
+//         ->name('verification.notice');
 
-    Route::get('verify-email/{id}/{hash}', VerifyEmailController::class)
-        ->middleware(['signed', 'throttle:6,1'])
-        ->name('verification.verify');
+//     Route::get('verify-email/{id}/{hash}', VerifyEmailController::class)
+//         ->middleware(['signed', 'throttle:6,1'])
+//         ->name('verification.verify');
 
-    Route::post('email/verification-notification', [EmailVerificationNotificationController::class, 'store'])
-        ->middleware('throttle:6,1')
-        ->name('verification.send');
+//     Route::post('email/verification-notification', [EmailVerificationNotificationController::class, 'store'])
+//         ->middleware('throttle:6,1')
+//         ->name('verification.send');
 
-    Route::get('confirm-password', [ConfirmablePasswordController::class, 'show'])
-        ->name('password.confirm');
+//     Route::get('confirm-password', [ConfirmablePasswordController::class, 'show'])
+//         ->name('password.confirm');
 
-    Route::post('confirm-password', [ConfirmablePasswordController::class, 'store']);
+//     Route::post('confirm-password', [ConfirmablePasswordController::class, 'store']);
 
-    Route::put('password', [PasswordController::class, 'update'])->name('password.update');
+//     Route::put('password', [PasswordController::class, 'update'])->name('password.update');
 
-    Route::post('logout', [AuthenticatedSessionController::class, 'destroy'])
-        ->name('logout');
-});
+//     Route::post('logout', [AuthenticatedSessionController::class, 'destroy'])
+//         ->name('logout');
+// });

--- a/routes/web.php
+++ b/routes/web.php
@@ -1,84 +1,44 @@
 <?php
 
+use App\Http\Controllers\ListController;
+use App\Http\Controllers\MovieController;
 use App\Http\Controllers\ProfileController;
+use App\Http\Controllers\ReviewController;
 use Illuminate\Support\Facades\Route;
 
-Route::get('/', function () {
-    return view('home');
+Route::controller(MovieController::class)->group(function () {
+    Route::get('/', 'index')->name('home');
+    Route::get('/m/{id}/{title}', 'show')->name('movie');
 });
 
-Route::get('/sign-up', function () {
-    return view('auth.sign-up');
+Route::controller(ProfileController::class)->group(function () {
+    Route::get('/u/{username}', 'show')->name('profile');
 });
 
-Route::get('/log-in', function () {
-    return view('auth.log-in');
+Route::controller(ListController::class)->group(function () {
+    Route::get('/u/{username}/lists', 'index')->name('lists');
+    Route::get('/list/{id}', 'show')->name('list');
 });
 
-Route::get('/u/{username}', function () {
-    return view('profile');
+Route::controller(ReviewController::class)->group(function () {
+    Route::get('/u/{username}/reviews', 'index')->name('reviews.user');
+    Route::get('/m/{id}/{title}/reviews', 'index')->name('reviews.movie');
+    Route::get('/review/{id}', 'show')->name('review');
 });
 
-Route::get('/u/{username}/lists', function () {
-    return view('lists');
-});
+// TODO: create admin middleware
+// FIXME: i think we need an admin controller?
+Route::middleware(['auth', 'admin'])->prefix('/admin')->group(function () {
+    Route::get('/', fn () => view('admin.dashboard'))->name('admin.dashboard');
+    Route::get('/create-movie', [MovieController::class, 'create'])->name('admin.create.movie');
+    Route::get('/create-user', fn () => view('admin.create-user'))->name('admin.create.user');
+    Route::get('/users', fn () => view('admin.users'))->name('admin.users');
+    Route::get('/featured', fn () => view('admin.featured-lists'))->name('admin.featured');
 
-Route::get('/u/{username}/reviews', function () {
-    return view('reviews');
-});
-
-Route::get('/m/{id}/{title}', function () {
-    return view('movie');
-});
-
-Route::get('/m/{id}/{title}/reviews', function () {
-    return view('reviews');
-});
-
-Route::get('/review/{id}', function () {
-    return view('review');
-});
-
-Route::get('/list/{id}', function () {
-    return view('movie-list');
-});
-
-Route::get('/admin', function () {
-    return view('admin.dashboard');
-});
-
-Route::get('/admin/create-movie', function () {
-    return view('admin.create-movie');
-});
-
-Route::get('/admin/create-user', function () {
-    return view('admin.create-user');
-});
-
-Route::get('/admin/users', function () {
-    return view('admin.users');
-});
-
-Route::get('/admin/featured', function () {
-    return view('admin.featured-lists');
-});
-
-Route::get('/admin/reports/users', function () {
-    return view('admin.reported-users');
-});
-
-Route::get('/admin/reports/reviews', function () {
-    return view('admin.reported-reviews');
-});
-
-Route::get('/dashboard', function () {
-    return view('dashboard');
-})->middleware(['auth', 'verified'])->name('dashboard');
-
-Route::middleware('auth')->group(function () {
-    Route::get('/profile', [ProfileController::class, 'edit'])->name('profile.edit');
-    Route::patch('/profile', [ProfileController::class, 'update'])->name('profile.update');
-    Route::delete('/profile', [ProfileController::class, 'destroy'])->name('profile.destroy');
+    Route::controller(ReviewController::class)->prefix('/reports')->group(function () {
+        Route::get('/users', 'index')->name('reports.user');
+        Route::get('/reviews', 'index')->name('reports.review');
+    });
 });
 
 require __DIR__.'/auth.php';


### PR DESCRIPTION
closes #281 

when we created all of our routes we didn't connect them to the intended controller. this connects all routes to their respective controllers. as well as provides some organization. i decided to organize with controller groups, except for the admin routes which are kept together to ensure all of them are behind the admin middleware (that doesn't exist yet)

i also think we will need to create an admin controller to handle all of the admin specific pages and actions

tldr:
- group routes into controller groups
- group admin routes into a group with admin middleware
- move views from routes to controllers
- move auth related routes into `routes/auth.php`
- comment out auth related routes we have not yet implemented