### PR TITLE
feat: add profile simplified compoenent

### DIFF
--- a/resources/views/components/profile-simplified.blade.php
+++ b/resources/views/components/profile-simplified.blade.php
@@ -4,7 +4,22 @@
     'size',
 ])
 
-<div class="flex items-center gap-2">
+<div
+    @class([
+        'flex',
+        'items-center',
+        'gap-1' => $size === 'sm',
+        'gap-2' => $size === 'md',
+    ])
+>
     <x-avatar :image="$image" :size="$size" />
-    <p class="text-slate-50">{{ $username }}</p>
+    <p
+        @class([
+            'text-slate-50',
+            'text-sm' => $size === 'sm',
+            'text-base' => $size === 'md',
+        ])
+    >
+        {{ $username }}
+    </p>
 </div>

--- a/resources/views/components/profile-simplified.blade.php
+++ b/resources/views/components/profile-simplified.blade.php
@@ -1,0 +1,10 @@
+@props([
+    'username',
+    'image',
+    'size',
+])
+
+<div class="flex items-center gap-2">
+    <x-avatar :image="$image" :size="$size" />
+    <p class="text-slate-50">{{ $username }}</p>
+</div>


### PR DESCRIPTION
## This PR includes the component for simplified profile
It takes in these props 
- username
- image
- size

### Example usage:
```blade 
<x-profile-simplified
    username="Jane Doe"
    size="md"
    image="https://images.unsplash.com/photo-1534528741775-53994a69daeb?q=80&w=2864&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D"
/> 
```

closes #218 