### PR TITLE
feat: section component

### DIFF
--- a/resources/css/app.css
+++ b/resources/css/app.css
@@ -19,3 +19,14 @@
     @apply outline-1;
   }
 }
+
+@layer utils {
+  .hide-scrollbar::-webkit-scrollbar {
+    display: none;
+  }
+
+  .hide-scrollbar {
+    -ms-overflow-style: none;
+    scrollbar-width: none;
+  }
+}

--- a/resources/views/components/section.blade.php
+++ b/resources/views/components/section.blade.php
@@ -20,6 +20,7 @@
 
     function generateVariable(string $breakpoint, int $number)
     {
+        validateBreakpoint($breakpoint);
         return '--section-grid-cols-' . $breakpoint . ': repeat(' . $number . ', minmax(0, 1fr))';
     }
 

--- a/resources/views/components/section.blade.php
+++ b/resources/views/components/section.blade.php
@@ -1,0 +1,54 @@
+@props([
+    'columns',
+    'scrollableOnMobile' => false,
+])
+
+@php
+    if (! isset($columns[0])) {
+        throw new Exception('a start column value must be provided');
+    }
+
+    $twVariables = [];
+
+    function validateBreakpoint(string $breakpoint)
+    {
+        $validBreakpoints = ['base', 'sm', 'md', 'lg'];
+        if (! in_array($breakpoint, $validBreakpoints)) {
+            throw new Exception("$breakpoint is not a valid breakpoint");
+        }
+    }
+
+    function generateVariable(string $breakpoint, int $number)
+    {
+        return '--section-grid-cols-' . $breakpoint . ': repeat(' . $number . ', minmax(0, 1fr))';
+    }
+
+    foreach ($columns as $breakpoint => $number) {
+        if ($breakpoint === 0) {
+            $twVariables[] = generateVariable('base', $number);
+        } else {
+            $twVariables[] = generateVariable($breakpoint, $number);
+        }
+    }
+
+    $styleAttributeValue = implode('; ', $twVariables);
+@endphp
+
+<section
+    style="{{ $styleAttributeValue }}"
+    @class([
+        'grid *:size-full' => ! $scrollableOnMobile,
+        'hide-scrollbar relative -mr-4 flex snap-x overflow-x-scroll *:snap-start *:not-[.gradient]:min-w-32 sm:mr-0 sm:grid sm:*:size-full' => $scrollableOnMobile,
+        'sm:grid-cols-(--section-grid-cols-sm)' => isset($columns['sm']),
+        'md:grid-cols-(--section-grid-cols-md)' => isset($columns['md']),
+        'lg:grid-cols-(--section-grid-cols-lg)' => isset($columns['lg']),
+        'grid-cols-(--section-grid-cols-base) gap-4',
+    ])
+>
+    {{ $slot }}
+    @if ($scrollableOnMobile)
+        <div
+            class="gradient pointer-events-none fixed -right-4 h-full w-12 bg-linear-to-l from-slate-800 to-slate-800/0 sm:hidden"
+        ></div>
+    @endif
+</section>


### PR DESCRIPTION
closes #58 

- supports setting different amounts columns at different breakpoints
  - it expects a base size and can then take any or all of these tailwind breakpoints: `sm`, `md`, `lg`
  - how it works is that the column prop provided will be transformed into an css variable that will then be used together with tailwinds breakpoints to change the amount of columns
- can be scrollable on mobile
  - will switch back to non scrollable variant at `sm:`
- takes a slot where any item can be rendered, the sizing of the item will be dynamic according to the grid

### example usage with movies
```blade
<x-section :columns="[3, 'sm' => 4, 'lg' => 6]" scrollableOnMobile>
    @foreach ($movies as $movie)
        <x-movie
            title="{{ $movie['title'] }}"
            rating="{{ $movie['rating'] }}"
            image="{{ $movie['cover'] }}"
        />
    @endforeach
</x-section>
```

https://github.com/user-attachments/assets/cda295dd-f1b7-4b5a-9ee5-38ac6b6eeba1

