### PR TITLE
fix: change `@if` to `@isset`

### DIFF
--- a/resources/views/components/section-header/link.blade.php
+++ b/resources/views/components/section-header/link.blade.php
@@ -5,9 +5,9 @@
 ])
 
 <div>
-    @if ($extraLabel)
+    @isset($extraLabel)
         <span class="text-sm text-indigo-400">{{ $extraLabel }}</span>
-    @endif
+    @endisset
 
     <a href="{{ $href }}" class="group flex flex-col">
         <div class="flex items-center gap-2">

--- a/resources/views/components/section-header/no-link.blade.php
+++ b/resources/views/components/section-header/no-link.blade.php
@@ -5,7 +5,7 @@
 
 <div class="flex gap-1">
     <h1 class="text-2xl font-bold text-slate-50">{{ $title }}</h1>
-    @if ($extraLabel)
+    @isset($extraLabel)
         <span class="text-xs text-indigo-400">{{ $extraLabel }}</span>
-    @endif
+    @endisset
 </div>


### PR DESCRIPTION
not providing an `extraLabel` causes the site to crash. by checking with `@isset` instead we get the expected behavior

![image](https://github.com/user-attachments/assets/ad63a299-7f37-4a4d-888e-d96ad3b7190e)