### PR TITLE
feat: date input

### DIFF
--- a/resources/css/app.css
+++ b/resources/css/app.css
@@ -30,6 +30,10 @@
     scrollbar-width: none;
   }
 
+  .hide-calendar-picker-indicator::-webkit-calendar-picker-indicator {
+    display: none;
+  }
+
   /* this is used by alpine.js to properly hide elements on load */
   [x-cloak] {
     @apply hidden;

--- a/resources/views/components/input/date.blade.php
+++ b/resources/views/components/input/date.blade.php
@@ -1,0 +1,31 @@
+@props([
+    'name',
+    'label',
+    'placeholder',
+    'value' => null,
+    'error',
+])
+
+<div
+    {{ $attributes->class('flex flex-col gap-1 ') }}
+    x-data
+>
+    <x-input.label for="{{ $name }}">
+        {{ $label }}
+    </x-input.label>
+    <div class="flex h-10 rounded-full bg-slate-700 px-3 py-2">
+        <button @click="$refs.datepicker.showPicker()" class="rounded-xs px-1">
+            <x-lucide-calendar class="size-4 text-slate-50" />
+        </button>
+        <input
+            type="date"
+            id="{{ $name }}"
+            name="{{ $name }}"
+            value="{{ $value }}"
+            placeholder="{{ $placeholder }}"
+            x-ref="datepicker"
+            class="hide-calendar-picker-indicator flex-1 rounded-xs px-1 text-base text-slate-50 placeholder:text-slate-400"
+        />
+    </div>
+    <x-input.error message="{{ $error }}" />
+</div>


### PR DESCRIPTION
closes #211

- date input with custom calendar button
- changing the placeholder to a custom one would require to build an entirely custom input with javascript so i decided not to spend time on that

### preview
<img width="764" alt="image" src="https://github.com/user-attachments/assets/438474aa-20c4-4fa1-844a-305be275a305" />
<img width="766" alt="image" src="https://github.com/user-attachments/assets/95bbb750-74b4-4814-b12a-3dab4a7e90ca" />
