### PR TITLE
fix: login and register route

### DIFF
--- a/app/Http/Controllers/Auth/NewPasswordController.php
+++ b/app/Http/Controllers/Auth/NewPasswordController.php
@@ -55,7 +55,7 @@ class NewPasswordController extends Controller
         // the application's home authenticated view. If there is an error we can
         // redirect them back to where they came from with their error message.
         return $status == Password::PASSWORD_RESET
-            ? redirect()->route('log-in')->with('status', __($status))
+            ? redirect()->route('login')->with('status', __($status))
             : back()->withInput($request->only('email'))
                 ->withErrors(['email' => __($status)]);
     }

--- a/resources/views/auth/log-in.blade.php
+++ b/resources/views/auth/log-in.blade.php
@@ -10,7 +10,7 @@
 
     <form
         method="post"
-        action="{{ route('log-in') }}"
+        action="{{ route('login') }}"
         class="flex flex-col gap-8"
     >
         @csrf
@@ -50,7 +50,7 @@
     <div class="flex flex-col items-center font-bold">
         <span>Don't have an account yet?</span>
         <a
-            href="{{ route('sign-up') }}"
+            href="{{ route('register') }}"
             class="flex items-center gap-1 text-indigo-300 transition hover:text-indigo-400"
         >
             Sign up

--- a/resources/views/auth/sign-up.blade.php
+++ b/resources/views/auth/sign-up.blade.php
@@ -10,7 +10,7 @@
 
     <form
         method="post"
-        action="{{ route('sign-up') }}"
+        action="{{ route('register') }}"
         class="flex flex-col gap-8"
     >
         @csrf
@@ -64,7 +64,7 @@
     <div class="flex flex-col items-center font-bold">
         <span>Already have an account?</span>
         <a
-            href="{{ route('log-in') }}"
+            href="{{ route('login') }}"
             class="flex items-center gap-1 text-indigo-300 transition hover:text-indigo-400"
         >
             Log in

--- a/resources/views/components/header.blade.php
+++ b/resources/views/components/header.blade.php
@@ -20,12 +20,12 @@
         @endauth
 
         @guest
-            <x-button size="sm" href="{{ route('log-in') }}" class="sm:hidden">
+            <x-button size="sm" href="{{ route('login') }}" class="sm:hidden">
                 Log in
             </x-button>
             <x-button
                 size="md"
-                href="{{ route('log-in') }}"
+                href="{{ route('login') }}"
                 class="hidden sm:flex"
             >
                 Log in

--- a/routes/auth.php
+++ b/routes/auth.php
@@ -13,13 +13,13 @@ use Illuminate\Support\Facades\Route;
 
 Route::middleware('guest')->group(function () {
     Route::controller(RegisteredUserController::class)->group(function () {
-        Route::get('/sign-up', 'create')->name('sign-up');
-        Route::post('/sign-up', 'store');
+        Route::get('/register', 'create')->name('register');
+        Route::post('/register', 'store');
     });
 
     Route::controller(AuthenticatedSessionController::class)->group(function () {
-        Route::get('/log-in', 'create')->name('log-in');
-        Route::post('/log-in', 'store');
+        Route::get('/login', 'create')->name('login');
+        Route::post('/login', 'store');
     });
 
     // Route::get('forgot-password', [PasswordResetLinkController::class, 'create'])

--- a/tests/Feature/Auth/PasswordResetTest.php
+++ b/tests/Feature/Auth/PasswordResetTest.php
@@ -65,7 +65,7 @@ class PasswordResetTest extends TestCase
 
             $response
                 ->assertSessionHasNoErrors()
-                ->assertRedirect(route('log-in'));
+                ->assertRedirect(route('login'));
 
             return true;
         });


### PR DESCRIPTION
the magic "auth" middleware requires these routes to be named as laravel names them by default. this changes it back to the default. will fix these types of errors:

<img width="1440" alt="image" src="https://github.com/user-attachments/assets/5b89a0a7-59a1-4094-99ff-0275ff2fa96b" />