### PR TITLE
fix: remove duplicate package-lock key

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -739,22 +739,6 @@
         "node": ">= 10"
       }
     },
-    "node_modules/@tailwindcss/oxide-android-arm64": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-android-arm64/-/oxide-android-arm64-4.0.0.tgz",
-      "integrity": "sha512-EAhjU0+FIdyGPR+7MbBWubLLPtmOu+p7c2egTTFBRk/n//zYjNvVK0WhcBK5Y7oUB5mo4EjA2mCbY7dcEMWSRw==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "android"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
     "node_modules/@tailwindcss/oxide-darwin-arm64": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-darwin-arm64/-/oxide-darwin-arm64-4.0.1.tgz",


### PR DESCRIPTION
we have a duplicate key in package-lock.json that has been causing some issues