### PR TITLE
feat: list settings menu

### DIFF
--- a/app/Models/MovieList.php
+++ b/app/Models/MovieList.php
@@ -22,11 +22,18 @@ class MovieList extends Model
         return $this->belongsToMany(Movie::class, 'list_movie', 'list_id', 'movie_id');
     }
 
-    // Define the many-to-many relationship with User
     public function users()
     {
         return $this->belongsToMany(User::class, 'list_user', 'list_id', 'user_id')
             ->withPivot('status', 'role')
             ->withTimestamps();
+    }
+
+    public function isOwnedBy(int $id)
+    {
+        return $this->users()
+            ->where('user_id', $id)
+            ->wherePivot('role', 'owner')
+            ->exists();
     }
 }

--- a/resources/views/components/menu-item.blade.php
+++ b/resources/views/components/menu-item.blade.php
@@ -1,11 +1,10 @@
 @props([
-    'label',
     'variant' => 'default',
-    'href',
+    'href' => null,
 ])
 
 @php
-    $baseClasses = 'block rounded-lg px-4 py-2 text-center transition-all duration-200 ease-out';
+    $baseClasses = 'block w-full cursor-pointer rounded-lg px-4 py-2 text-center transition-all duration-200 ease-out';
     $hoverClasses = 'hover:bg-slate-600';
 
     $variantClasses = match ($variant) {
@@ -20,12 +19,12 @@
         href="{{ $href }}"
         {{ $attributes->twMerge(['class' => "$baseClasses $variantClasses $hoverClasses"]) }}
     >
-        {{ $label }}
+        {{ $slot }}
     </a>
 @else
     <button
         {{ $attributes->twMerge(['class' => "$baseClasses $variantClasses $hoverClasses"]) }}
     >
-        {{ $label }}
+        {{ $slot }}
     </button>
 @endif

--- a/resources/views/components/modal/divider.blade.php
+++ b/resources/views/components/modal/divider.blade.php
@@ -1,0 +1,1 @@
+<div class="h-px w-full bg-slate-600"></div>

--- a/resources/views/components/modal/menu.blade.php
+++ b/resources/views/components/modal/menu.blade.php
@@ -3,7 +3,7 @@
 >
     <x-modal.title>{{ $title }}</x-modal.title>
     <div
-        class="flex w-full flex-col gap-2 divide-y-1 divide-slate-600 bg-slate-700 px-2 pt-4 pb-8 sm:rounded-2xl sm:p-2 [&>*]:pb-2"
+        class="flex w-full flex-col gap-2 bg-slate-700 px-2 pt-4 pb-8 sm:rounded-2xl sm:p-2"
     >
         {{ $slot }}
     </div>

--- a/resources/views/list.blade.php
+++ b/resources/views/list.blade.php
@@ -1,3 +1,45 @@
 <x-layout>
-    <h1>Movie list</h1>
+    @if ($isListOwner)
+        <x-button
+            x-data
+            @click="$dispatch('open-modal', 'edit-list')"
+            variant="icon"
+            srLabel="Open list settings"
+        >
+            <x-lucide-ellipsis-vertical class="size-6" />
+        </x-button>
+    @endif
+
+    <x-modal.base
+        name="edit-list"
+        :show="$errors->edit->isNotEmpty() || $errors->editListValidation->isNotEmpty()"
+    >
+        <x-modal.menu>
+            <x-slot:title>
+                {{ $list->title }}
+            </x-slot>
+            {{-- TODO: add edit mode --}}
+            <x-menu-item>Edit</x-menu-item>
+            <x-modal.divider />
+            {{-- TODO: open change visibility modal --}}
+            <x-menu-item>Change visibility</x-menu-item>
+            <x-modal.divider />
+            <form
+                method="post"
+                action="{{ route('list.destroy', ['id' => $list->id]) }}"
+            >
+                @csrf
+                @method('delete')
+                <x-menu-item variant="destructive">Delete list</x-menu-item>
+            </form>
+            <x-modal.divider />
+            <x-menu-item
+                x-data
+                @click="$dispatch('close-modal', 'edit-list')"
+                variant="highlights"
+            >
+                Cancel
+            </x-menu-item>
+        </x-modal.menu>
+    </x-modal.base>
 </x-layout>

--- a/routes/web.php
+++ b/routes/web.php
@@ -20,6 +20,7 @@ Route::controller(ListController::class)->group(function () {
     Route::get('/u/{username}/lists', 'index')->name('lists');
     Route::get('/list/{id}', 'show')->name('list');
     Route::post('/list', 'store')->middleware(['auth'])->name('list.store');
+    Route::delete('/list/{id}', 'destroy')->middleware(['auth'])->name('list.destroy');
 });
 
 Route::controller(ReviewController::class)->group(function () {


### PR DESCRIPTION
closes #117

- render menu button only for owners of the list
- create modal with options:
  - edit (to be implemented)
  - change visibility (to be implemented)
  - delete
- `destroy` method for deleting a list you are the owner of
- create `isOwnedBy` method on the `MovieList` model

- detached the divider from `modal.menu` and created its own component `modal.divider` because the styling wasn't working as intended
- some minor changes to `menu-item` to make it work with the modal

### test
- log in (if you're not logged in you should not see the ellipsis icon)
- go to `/u/{username}/lists`'
- create a list
- try to delete the list