### PR TITLE
feat: review menu

### DIFF
--- a/app/Http/Controllers/ListController.php
+++ b/app/Http/Controllers/ListController.php
@@ -94,7 +94,6 @@ class ListController extends Controller
         } catch (Exception) {
             return redirect()
                 ->back()
-                ->withInput()
                 ->withErrors('Something went wrong when deleting the list!', 'deleteList');
         }
     }

--- a/app/Http/Controllers/ReviewController.php
+++ b/app/Http/Controllers/ReviewController.php
@@ -87,8 +87,23 @@ class ReviewController extends Controller
     /**
      * Remove the specified resource from storage.
      */
-    public function destroy(Review $review)
+    public function destroy($id)
     {
-        //
+        try {
+            $review = Review::findOrFail($id);
+            $user = Auth::user();
+
+            if (! $review->isWrittenBy($user) && $user->role !== 'admin') {
+                throw new Exception('You are not allowed to delete this review');
+            }
+
+            $review->delete();
+
+            return redirect(route('home'));
+        } catch (Exception) {
+            return redirect()
+                ->back()
+                ->withErrors('Something went wrong when deleting the review!', 'deleteReview');
+        }
     }
 }

--- a/app/Http/Controllers/ReviewController.php
+++ b/app/Http/Controllers/ReviewController.php
@@ -63,8 +63,9 @@ class ReviewController extends Controller
     public function show($id)
     {
         $review = Review::with(['user', 'movie'])->findOrFail($id);
+        $isAuthor = Auth::check() && $review->isWrittenBy(Auth::user());
 
-        return view('review', ['review' => $review]);
+        return view('review', ['review' => $review, 'isAuthor' => $isAuthor]);
     }
 
     /**

--- a/app/Models/Review.php
+++ b/app/Models/Review.php
@@ -45,4 +45,9 @@ class Review extends Model
     {
         return $this->belongsTo(Movie::class);
     }
+
+    public function isWrittenBy(User $user): bool
+    {
+        return $this->user()->is($user);
+    }
 }

--- a/resources/views/components/input/error.blade.php
+++ b/resources/views/components/input/error.blade.php
@@ -3,7 +3,7 @@
 ])
 
 @if ($message)
-    <span class="text-sm text-red-400">
+    <span {{ $attributes->class('text-sm text-red-400') }}>
         {{ $message }}
     </span>
 @endif

--- a/resources/views/components/modal/menu.blade.php
+++ b/resources/views/components/modal/menu.blade.php
@@ -1,10 +1,15 @@
+@props(['error' => null])
+
 <div
-    class="relative flex w-full flex-col gap-2 self-end sm:max-w-xl sm:self-center"
+    class="relative flex w-full flex-col items-center gap-2 self-end sm:max-w-xl sm:self-center"
 >
     <x-modal.title>{{ $title }}</x-modal.title>
+
     <div
         class="flex w-full flex-col gap-2 bg-slate-700 px-2 pt-4 pb-8 sm:rounded-2xl sm:p-2"
     >
         {{ $slot }}
     </div>
+
+    <x-input.error :message="$error" class="absolute -bottom-8" />
 </div>

--- a/resources/views/list.blade.php
+++ b/resources/views/list.blade.php
@@ -10,11 +10,8 @@
         </x-button>
     @endif
 
-    <x-modal.base
-        name="edit-list"
-        :show="$errors->edit->isNotEmpty() || $errors->editListValidation->isNotEmpty()"
-    >
-        <x-modal.menu>
+    <x-modal.base name="edit-list" :show="$errors->deleteList->isNotEmpty()">
+        <x-modal.menu :error="$errors->deleteList->first()">
             <x-slot:title>
                 {{ $list->title }}
             </x-slot>

--- a/resources/views/review.blade.php
+++ b/resources/views/review.blade.php
@@ -58,9 +58,9 @@
 
     <x-modal.base
         name="review-menu"
-        {{-- :show="$errors->edit->isNotEmpty() || $errors->editListValidation->isNotEmpty()" --}}
+        :show="$errors->deleteReview->isNotEmpty()"
     >
-        <x-modal.menu>
+        <x-modal.menu :error="$errors->deleteReview->first()">
             <x-slot:title>
                 @if ($isAuthor)
                     <p class="font-normal">
@@ -95,8 +95,14 @@
             @endif
 
             @if ($isAuthor || auth()->user()->role === 'admin')
-                {{-- TODO: delete reivew --}}
-                <x-menu-item variant="destructive">Delete</x-menu-item>
+                <form
+                    method="post"
+                    action="{{ route('review.destroy', ['id' => $review->id]) }}"
+                >
+                    @csrf
+                    @method('delete')
+                    <x-menu-item variant="destructive">Delete</x-menu-item>
+                </form>
                 <x-modal.divider />
             @endif
 

--- a/resources/views/review.blade.php
+++ b/resources/views/review.blade.php
@@ -13,6 +13,8 @@
             backLabel="{{ $backLabel }}"
         />
         <x-button
+            x-data
+            @click="$dispatch('open-modal', 'review-menu')"
             variant="icon"
             srLabel="Open review menu"
             class="hidden sm:block"
@@ -53,4 +55,58 @@
     <p class="mt-6 max-w-xl text-slate-100">
         {!! $review->content !!}
     </p>
+
+    <x-modal.base
+        name="review-menu"
+        {{-- :show="$errors->edit->isNotEmpty() || $errors->editListValidation->isNotEmpty()" --}}
+    >
+        <x-modal.menu>
+            <x-slot:title>
+                @if ($isAuthor)
+                    <p class="font-normal">
+                        Review of
+                        <span class="font-bold">
+                            {{ $review->movie->title }}
+                        </span>
+                    </p>
+                @else
+                    <p class="font-normal">
+                        <span class="font-bold">
+                            {{ $review->user->username }}'s
+                        </span>
+                        review of
+                        <span class="font-bold">
+                            {{ $review->movie->title }}
+                        </span>
+                    </p>
+                @endif
+            </x-slot>
+
+            @if (! $isAuthor)
+                {{-- TODO: open report review modal --}}
+                <x-menu-item>Report</x-menu-item>
+                <x-modal.divider />
+            @endif
+
+            @if ($isAuthor)
+                {{-- TODO: open edit review modal --}}
+                <x-menu-item>Edit</x-menu-item>
+                <x-modal.divider />
+            @endif
+
+            @if ($isAuthor || auth()->user()->role === 'admin')
+                {{-- TODO: delete reivew --}}
+                <x-menu-item variant="destructive">Delete</x-menu-item>
+                <x-modal.divider />
+            @endif
+
+            <x-menu-item
+                x-data
+                @click="$dispatch('close-modal', 'review-menu')"
+                variant="highlights"
+            >
+                Cancel
+            </x-menu-item>
+        </x-modal.menu>
+    </x-modal.base>
 </x-layout>

--- a/resources/views/review.blade.php
+++ b/resources/views/review.blade.php
@@ -94,7 +94,7 @@
                 <x-modal.divider />
             @endif
 
-            @if ($isAuthor || auth()->user()->role === 'admin')
+            @if ($isAuthor || (auth()->check() && auth()->user()->role === 'admin'))
                 <form
                     method="post"
                     action="{{ route('review.destroy', ['id' => $review->id]) }}"

--- a/routes/web.php
+++ b/routes/web.php
@@ -28,6 +28,7 @@ Route::controller(ReviewController::class)->group(function () {
     Route::get('/m/{id}/{title}/reviews', 'index')->name('reviews.movie');
     Route::get('/review/{id}', 'show')->name('review');
     Route::post('/m/{id}/{title}', 'store')->middleware(['auth'])->name('review.store');
+    Route::delete('/review/{id}', 'destroy')->middleware(['auth'])->name('review.destroy');
 });
 
 Route::middleware(['auth', AdminMiddleware::class])->prefix('/admin')->group(function () {


### PR DESCRIPTION
closes #387 

- modal with conditional menu items
- delete review method
  - reviews can be deleted by the author or an admin
- support for menu modal to display an error (visible in the preview)
  - (also updated the list menu to display the error)
- `isWrittenBy` method on `Review` model 

### preview
<img width="1552" alt="image" src="https://github.com/user-attachments/assets/fd17da6e-7bf0-467d-bd47-a857d654f0fa" />

### test
- go to a review
- open the menu
- only report review should be visible
- log in
- go to a review you have created
- open the menu
- edit and delete should be visible
- try to delete the review
- log in to an admin account
- go to a review
- report and delete should be visible
- try to delete the review