### PR TITLE
feat: update review modal

### DIFF
--- a/app/Http/Controllers/ReviewController.php
+++ b/app/Http/Controllers/ReviewController.php
@@ -80,6 +80,11 @@ class ReviewController extends Controller
 
         try {
             $review = Review::findOrFail($id);
+            $user = Auth::user();
+
+            if (! $review->isWrittenBy($user)) {
+                throw new Exception('You are not allowed to edit this review');
+            }
 
             $review->update([
                 'rating' => $request->rating,

--- a/app/Http/Controllers/ReviewController.php
+++ b/app/Http/Controllers/ReviewController.php
@@ -69,19 +69,30 @@ class ReviewController extends Controller
     }
 
     /**
-     * Show the form for editing the specified resource.
-     */
-    public function edit(Review $review)
-    {
-        //
-    }
-
-    /**
      * Update the specified resource in storage.
      */
-    public function update(Request $request, Review $review)
+    public function update(Request $request, $id)
     {
-        //
+        $request->validateWithBag('updateReviewValidation', [
+            'rating' => ['required', 'integer', 'min:1', 'max:10'],
+            'content' => ['nullable', 'string', 'max:800'],
+        ]);
+
+        try {
+            $review = Review::findOrFail($id);
+
+            $review->update([
+                'rating' => $request->rating,
+                'content' => $request->content,
+            ]);
+
+            return redirect(route('review', ['id' => $review->id]));
+        } catch (Exception) {
+            return redirect()
+                ->back()
+                ->withInput()
+                ->withErrors('Something went wrong when updating the review!', 'updateReview');
+        }
     }
 
     /**

--- a/resources/views/review.blade.php
+++ b/resources/views/review.blade.php
@@ -92,7 +92,7 @@
                 <x-menu-item
                     x-data
                     @click="
-                    $dispatch('open-modal', 'edit-review')
+                    $dispatch('open-modal', 'update-review')
                     $dispatch('close-modal', 'review-menu')
                     "
                 >
@@ -124,8 +124,8 @@
     </x-modal.base>
 
     <x-modal.base
-        name="edit-review"
-        :show="$errors->editReview->isNotEmpty() || $errors->editReviewValidation->isNotEmpty()"
+        name="update-review"
+        :show="$errors->updateReview->isNotEmpty() || $errors->updateReviewValidation->isNotEmpty()"
     >
         <x-modal.input>
             <x-slot:title>
@@ -144,25 +144,25 @@
                         name="rating"
                         :value="old('rating') ? old('rating') : $review->rating"
                         required
-                        :error="$errors->editReviewValidation->first('rating')"
+                        :error="$errors->updateReviewValidation->first('rating')"
                         label="Your rating"
                     />
                     <x-input.textarea
                         name="content"
                         :value="old('content') ? old('content') : $review->content"
-                        :error="$errors->editReviewValidation->first('content')"
+                        :error="$errors->updateReviewValidation->first('content')"
                         label="Review"
                         placeholder="Let others know why they should (or shouldn't) watch this film."
                         color="light"
                     />
                 </div>
 
-                <x-input.error :message="$errors->editReview->first()" />
+                <x-input.error :message="$errors->updateReview->first()" />
 
                 <div class="flex gap-2">
                     <x-button
                         x-data
-                        @click="$dispatch('close-modal', 'edit-review')"
+                        @click="$dispatch('close-modal', 'update-review')"
                         type="button"
                         variant="secondary"
                     >

--- a/resources/views/review.blade.php
+++ b/resources/views/review.blade.php
@@ -89,8 +89,15 @@
             @endif
 
             @if ($isAuthor)
-                {{-- TODO: open edit review modal --}}
-                <x-menu-item>Edit</x-menu-item>
+                <x-menu-item
+                    x-data
+                    @click="
+                    $dispatch('open-modal', 'edit-review')
+                    $dispatch('close-modal', 'review-menu')
+                    "
+                >
+                    Edit
+                </x-menu-item>
                 <x-modal.divider />
             @endif
 
@@ -114,5 +121,56 @@
                 Cancel
             </x-menu-item>
         </x-modal.menu>
+    </x-modal.base>
+
+    <x-modal.base
+        name="edit-review"
+        :show="$errors->editReview->isNotEmpty() || $errors->editReviewValidation->isNotEmpty()"
+    >
+        <x-modal.input>
+            <x-slot:title>
+                {{ $review->movie->title }}
+            </x-slot>
+            <form
+                method="post"
+                action="{{ route('review.update', ['id' => $review->id]) }}"
+                class="flex flex-col gap-6"
+            >
+                @csrf
+                @method('put')
+
+                <div class="flex flex-col gap-4">
+                    <x-input.rating
+                        name="rating"
+                        :value="old('rating') ? old('rating') : $review->rating"
+                        required
+                        :error="$errors->editReviewValidation->first('rating')"
+                        label="Your rating"
+                    />
+                    <x-input.textarea
+                        name="content"
+                        :value="old('content') ? old('content') : $review->content"
+                        :error="$errors->editReviewValidation->first('content')"
+                        label="Review"
+                        placeholder="Let others know why they should (or shouldn't) watch this film."
+                        color="light"
+                    />
+                </div>
+
+                <x-input.error :message="$errors->editReview->first()" />
+
+                <div class="flex gap-2">
+                    <x-button
+                        x-data
+                        @click="$dispatch('close-modal', 'edit-review')"
+                        type="button"
+                        variant="secondary"
+                    >
+                        Cancel
+                    </x-button>
+                    <x-button class="flex-1">Update review</x-button>
+                </div>
+            </form>
+        </x-modal.input>
     </x-modal.base>
 </x-layout>

--- a/routes/web.php
+++ b/routes/web.php
@@ -29,6 +29,7 @@ Route::controller(ReviewController::class)->group(function () {
     Route::get('/review/{id}', 'show')->name('review');
     Route::post('/m/{id}/{title}', 'store')->middleware(['auth'])->name('review.store');
     Route::delete('/review/{id}', 'destroy')->middleware(['auth'])->name('review.destroy');
+    Route::put('/review/{id}', 'update')->middleware(['auth'])->name('review.update');
 });
 
 Route::middleware(['auth', AdminMiddleware::class])->prefix('/admin')->group(function () {


### PR DESCRIPTION
closes #383 

- modal for editing a review
- `update` method in `Review` model
- open modal from the `review-menu` modal

### preview
<img width="1552" alt="image" src="https://github.com/user-attachments/assets/9763d8c8-6e47-42df-a381-4415dde847e7" />

### test
- log in
- go to a review you have created
- try to edit it