### PR TITLE
feat: render profile section

### DIFF
--- a/resources/views/components/profile.blade.php
+++ b/resources/views/components/profile.blade.php
@@ -1,41 +1,42 @@
 @props([
     'user',
-    'stats' => [
-        'lists' => 0,
-        'reviews' => 0,
-        'friends' => 0,
-    ],
-    
+    'statistics',
 ])
 
 <div class="relative flex w-full">
-    <div class="absolute top-0 right-0">
-        <x-lucide-ellipsis-vertical class="size-6 text-slate-50" />
+    <div
+        class="mr-8 flex w-full flex-col gap-4 md:flex-row md:items-center md:justify-between"
+    >
+        <div class="flex gap-4">
+            <x-avatar :image="$user->image" size="lg" />
+
+            <div class="flex grow flex-col gap-3 text-slate-50">
+                <div class="text-lg font-bold">
+                    {{ $user->username }}
+                </div>
+                <div class="flex gap-6 text-slate-50">
+                    @foreach ($statistics as $name => $number)
+                        <div class="flex flex-col text-sm">
+                            <p class="font-bold">
+                                {{ $number }}
+                            </p>
+                            <span class="text-slate-200">
+                                {{ $name }}
+                            </span>
+                        </div>
+                    @endforeach
+                </div>
+            </div>
+        </div>
+
+        @isset($buttons)
+            <div class="flex flex-none gap-2 self-start">
+                {{ $buttons }}
+            </div>
+        @endisset
     </div>
 
-    <div class="mr-8 flex w-full flex-row flex-wrap items-center gap-4">
-        <x-avatar :image="$user->image ?? null" size="lg" />
-
-        <div class="flex grow flex-col gap-3 text-slate-50">
-            <div class="text-lg font-bold">
-                {{ $user->username }}
-            </div>
-            <div class="flex gap-6 text-slate-50">
-                @foreach ($stats as $stat => $sum)
-                    <div class="flex flex-col">
-                        <p class="text-sm font-bold">
-                            {{ $sum }}
-                        </p>
-                        <span class="text-sm font-normal text-slate-200">
-                            {{ $stat }}
-                        </span>
-                    </div>
-                @endforeach
-            </div>
-        </div>
-
-        <div class="flex flex-none flex-row gap-2 self-start">
-            {{ $slot }}
-        </div>
+    <div class="absolute top-0 right-0">
+        <x-lucide-ellipsis-vertical class="size-6 text-slate-50" />
     </div>
 </div>

--- a/resources/views/components/profile.blade.php
+++ b/resources/views/components/profile.blade.php
@@ -7,7 +7,7 @@
     <div
         class="mr-8 flex w-full flex-col gap-4 md:flex-row md:items-center md:justify-between"
     >
-        <div class="flex gap-4">
+        <div class="flex items-center gap-4">
             <x-avatar :image="$user->image" size="lg" />
 
             <div class="flex grow flex-col gap-3 text-slate-50">

--- a/resources/views/profile.blade.php
+++ b/resources/views/profile.blade.php
@@ -1,45 +1,63 @@
 @php
-    $listsTitle = $isCurrentUserProfile ? 'My lists' : "$username's lists";
-    $reviewsTitle = $isCurrentUserProfile ? 'My reviews' : "$username's reviews";
+    $listsTitle = $isCurrentUserProfile ? 'My lists' : "$user->username's lists";
+    $reviewsTitle = $isCurrentUserProfile
+        ? 'My reviews'
+        : "$user->username's reviews";
 @endphp
 
-<x-layout>
-    @if ($lists->isNotEmpty())
-        <div class="flex flex-col items-start gap-4">
-            <x-section-header.link
-                :title="$listsTitle"
-                href="{{ route('lists', ['username' => $username]) }}"
-            />
-            <x-section :columns="[2, 'md' => 4]">
-                @foreach ($lists as $list)
-                    <x-list
-                        :title="$list['title']"
-                        :posters="$list['posters']->toArray()"
-                        link="{{ route('list', ['id' => $list['id']]) }}"
-                    />
-                @endforeach
-            </x-section>
-        </div>
-    @endif
+<x-layout class="flex flex-col gap-16 pt-6">
+    <x-profile :user="$user" :statistics="$statistics">
+        @if (auth()->check() && auth()->user()->role === 'admin' && $isCurrentUserProfile)
+            <x-slot:buttons>
+                <x-button
+                    variant="secondary"
+                    size="sm"
+                    href="{{ route('admin.dashboard') }}"
+                >
+                    Go to admin dashboard
+                </x-button>
+            </x-slot>
+        @endif
+    </x-profile>
 
-    @if ($reviews->isNotEmpty())
-        <div class="flex flex-col items-start gap-4">
-            <x-section-header.link
-                :title="$reviewsTitle"
-                href="{{ route('reviews.user', ['username' => $username]) }}"
-            />
-            <x-section :columns="[1, 'md' => 2]">
-                @foreach ($reviews as $review)
-                    <x-review
-                        :title="$review->movie->title "
-                        :content="$review->content"
-                        :created_at="$review->created_at"
-                        :rating="$review->rating"
-                        :image="$review->movie->cover_image"
-                        link="{{ route('review', ['id' => $review->id]) }}"
-                    />
-                @endforeach
-            </x-section>
-        </div>
-    @endif
+    <div class="flex flex-col gap-12">
+        @if ($lists->isNotEmpty())
+            <div class="flex flex-col items-start gap-4">
+                <x-section-header.link
+                    :title="$listsTitle"
+                    href="{{ route('lists', ['username' => $user->username]) }}"
+                />
+                <x-section :columns="[2, 'md' => 4]">
+                    @foreach ($lists as $list)
+                        <x-list
+                            :title="$list['title']"
+                            :posters="$list['posters']->toArray()"
+                            link="{{ route('list', ['id' => $list['id']]) }}"
+                        />
+                    @endforeach
+                </x-section>
+            </div>
+        @endif
+
+        @if ($reviews->isNotEmpty())
+            <div class="flex flex-col items-start gap-4">
+                <x-section-header.link
+                    :title="$reviewsTitle"
+                    href="{{ route('reviews.user', ['username' => $user->username]) }}"
+                />
+                <x-section :columns="[1, 'md' => 2]">
+                    @foreach ($reviews as $review)
+                        <x-review
+                            :title="$review->movie->title "
+                            :content="$review->content"
+                            :created_at="$review->created_at"
+                            :rating="$review->rating"
+                            :image="$review->movie->cover_image"
+                            link="{{ route('review', ['id' => $review->id]) }}"
+                        />
+                    @endforeach
+                </x-section>
+            </div>
+        @endif
+    </div>
 </x-layout>

--- a/resources/views/profile.blade.php
+++ b/resources/views/profile.blade.php
@@ -20,44 +20,56 @@
         @endif
     </x-profile>
 
-    <div class="flex flex-col gap-12">
-        @if ($lists->isNotEmpty())
-            <div class="flex flex-col items-start gap-4">
-                <x-section-header.link
-                    :title="$listsTitle"
-                    href="{{ route('lists', ['username' => $user->username]) }}"
-                />
-                <x-section :columns="[2, 'md' => 4]">
-                    @foreach ($lists as $list)
-                        <x-list
-                            :title="$list['title']"
-                            :posters="$list['posters']->toArray()"
-                            link="{{ route('list', ['id' => $list['id']]) }}"
-                        />
-                    @endforeach
-                </x-section>
-            </div>
-        @endif
+    @if ($lists->isEmpty() && $reviews->isEmpty())
+        <div class="grid flex-1 place-items-center">
+            <p class="text-slate-200">
+                @if ($isCurrentUserProfile)
+                    You don't have any content yet!
+                @else
+                    {{ $user->username }} doesn't have any content yet!
+                @endif
+            </p>
+        </div>
+    @else
+        <div class="flex flex-col gap-12">
+            @if ($lists->isNotEmpty())
+                <div class="flex flex-col items-start gap-4">
+                    <x-section-header.link
+                        :title="$listsTitle"
+                        href="{{ route('lists', ['username' => $user->username]) }}"
+                    />
+                    <x-section :columns="[2, 'md' => 4]">
+                        @foreach ($lists as $list)
+                            <x-list
+                                :title="$list['title']"
+                                :posters="$list['posters']->toArray()"
+                                link="{{ route('list', ['id' => $list['id']]) }}"
+                            />
+                        @endforeach
+                    </x-section>
+                </div>
+            @endif
 
-        @if ($reviews->isNotEmpty())
-            <div class="flex flex-col items-start gap-4">
-                <x-section-header.link
-                    :title="$reviewsTitle"
-                    href="{{ route('reviews.user', ['username' => $user->username]) }}"
-                />
-                <x-section :columns="[1, 'md' => 2]">
-                    @foreach ($reviews as $review)
-                        <x-review
-                            :title="$review->movie->title "
-                            :content="$review->content"
-                            :created_at="$review->created_at"
-                            :rating="$review->rating"
-                            :image="$review->movie->cover_image"
-                            link="{{ route('review', ['id' => $review->id]) }}"
-                        />
-                    @endforeach
-                </x-section>
-            </div>
-        @endif
-    </div>
+            @if ($reviews->isNotEmpty())
+                <div class="flex flex-col items-start gap-4">
+                    <x-section-header.link
+                        :title="$reviewsTitle"
+                        href="{{ route('reviews.user', ['username' => $user->username]) }}"
+                    />
+                    <x-section :columns="[1, 'md' => 2]">
+                        @foreach ($reviews as $review)
+                            <x-review
+                                :title="$review->movie->title "
+                                :content="$review->content"
+                                :created_at="$review->created_at"
+                                :rating="$review->rating"
+                                :image="$review->movie->cover_image"
+                                link="{{ route('review', ['id' => $review->id]) }}"
+                            />
+                        @endforeach
+                    </x-section>
+                </div>
+            @endif
+        </div>
+    @endif
 </x-layout>


### PR DESCRIPTION
closes #97 

- render the profile part of the profile view
- some changes to `<x-profile />` to fit the use case
- some changes to how the profile data is being rendered
- empty state
- admin buttons for admins visiting their own profile

### preview
<img width="1552" alt="image" src="https://github.com/user-attachments/assets/84d68d77-fba3-4450-9388-601c177ecd69" />
<img width="1552" alt="image" src="https://github.com/user-attachments/assets/7792e2ab-7e51-4002-aab5-234bf6052723" />

### test
- go to a random profile
- go to your own profile (while logged in)
- make yourself an admin to see the dashboard button