### PR TITLE
feat: create info section movie view

### DIFF
--- a/app/Http/Controllers/MovieController.php
+++ b/app/Http/Controllers/MovieController.php
@@ -38,8 +38,8 @@ class MovieController extends Controller
      */
     public function show($id)
     {
-        $movie = Movie::findOrFail($id);
-
+        $movie = Movie::with(['reviews', 'genres'])->findOrFail($id);
+       
         return view('movie', ['movie' => $movie]);
     }
 

--- a/app/Http/Controllers/MovieController.php
+++ b/app/Http/Controllers/MovieController.php
@@ -39,7 +39,7 @@ class MovieController extends Controller
     public function show($id)
     {
         $movie = Movie::with(['reviews', 'genres'])->findOrFail($id);
-       
+
         return view('movie', ['movie' => $movie]);
     }
 

--- a/app/Http/Controllers/MovieController.php
+++ b/app/Http/Controllers/MovieController.php
@@ -4,6 +4,7 @@ namespace App\Http\Controllers;
 
 use App\Models\Movie;
 use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Auth;
 
 class MovieController extends Controller
 {
@@ -39,8 +40,13 @@ class MovieController extends Controller
     public function show($id)
     {
         $movie = Movie::with(['reviews', 'genres'])->findOrFail($id);
+        $user = Auth::user();
+        $isAdmin = $user && $user->role === 'admin';
 
-        return view('movie', ['movie' => $movie]);
+        return view('movie', [
+            'movie' => $movie,
+            'isAdmin' => $isAdmin,
+        ]);
     }
 
     /**

--- a/app/utils/helpers.php
+++ b/app/utils/helpers.php
@@ -27,11 +27,3 @@ function generateSectionGridVariable(string $breakpoint, int $number)
 
     return '--section-grid-cols-'.$breakpoint.': repeat('.$number.', minmax(0, 1fr))';
 }
-
-function formatDuration($minutes)
-{
-    $hours = floor($minutes / 60);
-    $mins = $minutes % 60;
-
-    return sprintf('%dh %02dm', $hours, $mins);
-}

--- a/app/utils/helpers.php
+++ b/app/utils/helpers.php
@@ -27,3 +27,11 @@ function generateSectionGridVariable(string $breakpoint, int $number)
 
     return '--section-grid-cols-'.$breakpoint.': repeat('.$number.', minmax(0, 1fr))';
 }
+
+function formatDuration($minutes)
+{
+    $hours = floor($minutes / 60);
+    $mins = $minutes % 60;
+
+    return sprintf('%dh %02dm', $hours, $mins);
+}

--- a/database/factories/ReviewFactory.php
+++ b/database/factories/ReviewFactory.php
@@ -27,8 +27,8 @@ class ReviewFactory extends Factory
     public function definition(): array
     {
         return [
-            'user_id' => User::factory(),
-            'movie_id' => Movie::factory(),
+            'movie_id' => Movie::all()->random()->id,
+            'user_id' => User::all()->random()->id,
             'rating' => $this->faker->numberBetween(1, 10),
             'content' => $this->faker->realText(rand(50, 800)),
         ];

--- a/resources/views/movie.blade.php
+++ b/resources/views/movie.blade.php
@@ -22,7 +22,7 @@
                         <p>{!! $movie->year !!}</p>
                         <div class="text-indigo-200 sm:hidden">|</div>
                         <p class="sm:hidden">
-                            {!! formatDuration($movie->duration) !!}
+                            {!! $movie->duration !!}
                         </p>
                     </div>
                     <p class="text-xs font-bold text-slate-100 sm:hidden">
@@ -100,7 +100,7 @@
             <div class="text-indigo-200">|</div>
             <p>{!! $movie->year !!}</p>
             <div class="text-indigo-200">|</div>
-            <p class="">{!! formatDuration($movie->duration) !!}</p>
+            <p class="">{!! $movie->duration !!}</p>
             <div class="text-indigo-200">|</div>
             <p class="text-xs font-bold text-slate-100">
                 {!! $movie->director !!}
@@ -122,7 +122,7 @@
                 <img
                     src="{{ $movie->cover_image }}"
                     alt="Cover image of {{ $movie->title }}"
-                    class="h-104 w-182 object-cover"
+                    class="h-104 w-182 rounded-xs object-cover"
                 />
                 <div class="flex flex-wrap gap-3">
                     @foreach ($movie->genres as $genre)

--- a/resources/views/movie.blade.php
+++ b/resources/views/movie.blade.php
@@ -1,36 +1,43 @@
-<x-layout>
+<x-layout class="px-0 sm:pt-18">
     <!-- Mobile View -->
     <img
         src="{{ $movie->cover_image }}"
         alt="Cover image of {{ $movie->title }}"
         class="h-64 w-full object-cover sm:hidden"
     />
-    <div class="flex justify-between pt-4 sm:hidden">
-        <div class="flex flex-col gap-4 sm:hidden">
-            <h1 class="text-2xl font-bold text-slate-50 sm:hidden">
-                {{ $movie->title }}
-            </h1>
-            <div class="flex flex-col gap-1 sm:hidden">
-                <div class="flex items-center gap-2 sm:hidden">
-                    <x-rating
-                        class="sm:hidden"
-                        size="sm"
-                        :rating="$movie->rating_average"
-                    />
-                    <div class="text-indigo-200 sm:hidden">|</div>
-                    <p>{{ $movie->year }}</p>
-                    <div class="text-indigo-200 sm:hidden">|</div>
-                    <p class="sm:hidden">{{ $movie->duration }}</p>
+    <div class="px-4">
+        <div class="flex justify-between pt-4 sm:hidden">
+            <div class="flex flex-col gap-4 sm:hidden">
+                <h1 class="text-2xl font-bold text-slate-50 sm:hidden">
+                    {{ $movie->title }}
+                </h1>
+                <div class="flex flex-col gap-1 sm:hidden">
+                    <div class="flex items-center gap-2 sm:hidden">
+                        <x-rating
+                            class="sm:hidden"
+                            size="sm"
+                            :rating="$movie->rating_average"
+                        />
+                        <div class="text-indigo-200 sm:hidden">|</div>
+                        <p>{{ $movie->year }}</p>
+                        <div class="text-indigo-200 sm:hidden">|</div>
+                        <p class="sm:hidden">{{ $movie->duration }}</p>
+                    </div>
+                    <p class="text-xs font-bold text-slate-100 sm:hidden">
+                        {{ $movie->director }}
+                    </p>
                 </div>
-                <p class="text-xs font-bold text-slate-100 sm:hidden">
-                    {{ $movie->director }}
-                </p>
+                <div class="flex flex-wrap gap-2 sm:hidden">
+                    @foreach ($movie->genres as $genre)
+                        <x-tag :label="$genre->name" link="" />
+                    @endforeach
+                </div>
             </div>
-            <div class="flex flex-wrap gap-2 sm:hidden">
-                @foreach ($movie->genres as $genre)
-                    <x-tag :label="$genre->name" link="" />
-                @endforeach
-            </div>
+            <x-poster
+                class="w-32 sm:hidden"
+                src="{{ $movie->poster }}"
+                alt="Poster of {{ $movie->title }}"
+            />
         </div>
         <x-poster class="w-32 sm:hidden" src="{{ $movie->poster }}" />
     </div>
@@ -54,6 +61,96 @@
         Add to list
     </x-button>
 
+    <div class="mt-2 flex gap-2 sm:hidden">
+        <p class="pt-3 sm:hidden">{{ $movie->description }}</p>
+        <x-button
+            class="mt-6 w-full sm:hidden"
+            variant="primary"
+            size="md"
+            href=""
+        >
+            Add to list
+        </x-button>
+        <div class="mt-2 flex gap-2 sm:hidden">
+            <x-button
+                class="w-full bg-red-400 sm:hidden"
+                variant="primary"
+                size="md"
+                href=""
+            >
+                Delete
+            </x-button>
+            <x-button
+                class="w-full sm:hidden"
+                variant="secondary"
+                size="md"
+                href=""
+            >
+                Edit
+            </x-button>
+        </div>
+    </div>
+
+    <!-- Desktop View -->
+    <div class="hidden px-4 sm:block">
+        <div class="flex items-center justify-between">
+            <h1 class="text-2xl font-bold text-slate-50">
+                {{ $movie->title }}
+            </h1>
+            <div class="flex gap-2">
+                <x-button
+                    class="bg-red-400 hover:bg-red-500"
+                    variant="primary"
+                    size="md"
+                    href=""
+                >
+                    Delete
+                </x-button>
+                <x-button class="" variant="secondary" size="md" href="">
+                    Edit
+                </x-button>
+            </div>
+        </div>
+        <div class="flex items-center gap-2">
+            <x-rating size="sm" :rating="$movie->rating_average" />
+            <div class="text-indigo-200">|</div>
+            <p>{{ $movie->year }}</p>
+            <div class="text-indigo-200">|</div>
+            <p class="">{{ $movie->duration }}</p>
+            <div class="text-indigo-200">|</div>
+            <p class="text-xs font-bold text-slate-100">
+                {{ $movie->director }}
+            </p>
+        </div>
+
+        <div class="flex gap-4 pt-3">
+            <div class="flex w-70 flex-col gap-3">
+                <x-poster
+                    class="h-104 min-w-70"
+                    src="{{ $movie->poster }}"
+                    alt="Poster of {{ $movie->title }}"
+                />
+                <x-button variant="primary" size="md" href="">
+                    Add movie
+                </x-button>
+            </div>
+            <div class="flex flex-col gap-3">
+                <img
+                    src="{{ $movie->cover_image }}"
+                    alt="Cover image of {{ $movie->title }}"
+                    class="h-104 w-182 object-cover"
+                />
+                <div class="flex flex-wrap gap-3">
+                    @foreach ($movie->genres as $genre)
+                        <x-tag :label="$genre->name" link="" />
+                    @endforeach
+                </div>
+            </div>
+        </div>
+        <p class="max-w-144 pt-3">
+            {{ $movie->description }}
+        </p>
+    </div>
     <x-button
         x-data
         @click="$dispatch('open-modal', 'create-review')"
@@ -62,25 +159,6 @@
     >
         Write a review
     </x-button>
-
-    <div class="mt-2 flex gap-2 sm:hidden">
-        <x-button
-            class="w-full bg-red-400 sm:hidden"
-            variant="primary"
-            size="md"
-            href=""
-        >
-            Delete
-        </x-button>
-        <x-button
-            class="w-full sm:hidden"
-            variant="secondary"
-            size="md"
-            href=""
-        >
-            Edit
-        </x-button>
-    </div>
     <x-modal.base
         name="create-review"
         :show="$errors->createReview->isNotEmpty() || $errors->createReviewValidation->isNotEmpty()"

--- a/resources/views/movie.blade.php
+++ b/resources/views/movie.blade.php
@@ -1,4 +1,51 @@
 <x-layout>
+    <img
+        src="{{ $movie->cover_image }}"
+        alt="Cover image of {{ $movie->title }}"
+        class="h-64 w-full object-cover"
+    />
+    <div class="flex justify-between pt-4">
+        <div class="flex flex-col gap-4">
+            <h1 class="text-2xl font-bold text-slate-50">
+                {{ $movie->title }}
+            </h1>
+            <div class="flex flex-col gap-1">
+                <div class="flex items-center gap-2">
+                    <x-rating size="sm" :rating="$movie->rating_average" />
+                    <div class="text-indigo-200">|</div>
+                    <p>{{ $movie->year }}</p>
+                    <div class="text-indigo-200">|</div>
+                    <p>{{ $movie->duration }}</p>
+                </div>
+                <p class="text-xs font-bold text-slate-100">
+                    {{ $movie->director }}
+                </p>
+            </div>
+            <div class="flex flex-wrap gap-2">
+                @foreach ($movie->genres as $genre)
+                    <x-tag :label="$genre->name" link="" />
+                @endforeach
+            </div>
+        </div>
+        <x-poster class="w-32" src="{{ $movie->poster }}" />
+    </div>
+    <div class="flex flex-col gap-3" x-data="{ showFullText: false }">
+        <p :class="{ 'line-clamp-3': !showFullText }" class="pt-3">
+            {{ $movie->description }}
+        </p>
+        <button
+            @click="showFullText = !showFullText"
+            class="cursor-pointer text-end text-sm font-bold text-indigo-400 hover:underline focus:outline-none"
+        >
+            <span x-show="!showFullText">Show more</span>
+            <span x-show="showFullText">Show less</span>
+        </button>
+    </div>
+
+    <x-button class="mt-6 w-full" variant="primary" size="md" href="">
+        Add to list
+    </x-button>
+
     <x-button
         x-data
         @click="$dispatch('open-modal', 'create-review')"

--- a/resources/views/movie.blade.php
+++ b/resources/views/movie.blade.php
@@ -111,7 +111,7 @@
                     alt="Poster of {{ $movie->title }}"
                 />
                 <x-button variant="primary" size="md" href="">
-                    Add movie
+                    Add to list
                 </x-button>
             </div>
             <div class="flex flex-col gap-3">

--- a/resources/views/movie.blade.php
+++ b/resources/views/movie.blade.php
@@ -131,6 +131,7 @@
             {!! $movie->description !!}
         </p>
     </div>
+
     <x-button
         x-data
         @click="$dispatch('open-modal', 'create-review')"
@@ -176,7 +177,7 @@
                 <div class="flex gap-2">
                     <x-button
                         x-data
-                        @click="$dispatch('close-modal', 'create-list')"
+                        @click="$dispatch('close-modal', 'create-review')"
                         type="button"
                         variant="secondary"
                     >

--- a/resources/views/movie.blade.php
+++ b/resources/views/movie.blade.php
@@ -1,48 +1,56 @@
 <x-layout>
+    <!-- Mobile View -->
     <img
         src="{{ $movie->cover_image }}"
         alt="Cover image of {{ $movie->title }}"
-        class="h-64 w-full object-cover"
+        class="h-64 w-full object-cover sm:hidden"
     />
-    <div class="flex justify-between pt-4">
-        <div class="flex flex-col gap-4">
-            <h1 class="text-2xl font-bold text-slate-50">
+    <div class="flex justify-between pt-4 sm:hidden">
+        <div class="flex flex-col gap-4 sm:hidden">
+            <h1 class="text-2xl font-bold text-slate-50 sm:hidden">
                 {{ $movie->title }}
             </h1>
-            <div class="flex flex-col gap-1">
-                <div class="flex items-center gap-2">
-                    <x-rating size="sm" :rating="$movie->rating_average" />
-                    <div class="text-indigo-200">|</div>
+            <div class="flex flex-col gap-1 sm:hidden">
+                <div class="flex items-center gap-2 sm:hidden">
+                    <x-rating
+                        class="sm:hidden"
+                        size="sm"
+                        :rating="$movie->rating_average"
+                    />
+                    <div class="text-indigo-200 sm:hidden">|</div>
                     <p>{{ $movie->year }}</p>
-                    <div class="text-indigo-200">|</div>
-                    <p>{{ $movie->duration }}</p>
+                    <div class="text-indigo-200 sm:hidden">|</div>
+                    <p class="sm:hidden">{{ $movie->duration }}</p>
                 </div>
-                <p class="text-xs font-bold text-slate-100">
+                <p class="text-xs font-bold text-slate-100 sm:hidden">
                     {{ $movie->director }}
                 </p>
             </div>
-            <div class="flex flex-wrap gap-2">
+            <div class="flex flex-wrap gap-2 sm:hidden">
                 @foreach ($movie->genres as $genre)
                     <x-tag :label="$genre->name" link="" />
                 @endforeach
             </div>
         </div>
-        <x-poster class="w-32" src="{{ $movie->poster }}" />
+        <x-poster class="w-32 sm:hidden" src="{{ $movie->poster }}" />
     </div>
-    <div class="flex flex-col gap-3" x-data="{ showFullText: false }">
-        <p :class="{ 'line-clamp-3': !showFullText }" class="pt-3">
+    <div
+        class="flex flex-col gap-3 sm:hidden"
+        x-data="{ showFullText: false }"
+    >
+        <p :class="{ 'line-clamp-3': !showFullText }" class="pt-3 sm:hidden">
             {{ $movie->description }}
         </p>
         <button
             @click="showFullText = !showFullText"
-            class="cursor-pointer text-end text-sm font-bold text-indigo-400 hover:underline focus:outline-none"
+            class="cursor-pointer text-end text-sm font-bold text-indigo-400 hover:underline focus:outline-none sm:hidden"
         >
             <span x-show="!showFullText">Show more</span>
             <span x-show="showFullText">Show less</span>
         </button>
     </div>
 
-    <x-button class="mt-6 w-full" variant="primary" size="md" href="">
+    <x-button class="mt-6 w-full sm:hidden" variant="primary" size="md" href="">
         Add to list
     </x-button>
 
@@ -55,6 +63,24 @@
         Write a review
     </x-button>
 
+    <div class="mt-2 flex gap-2 sm:hidden">
+        <x-button
+            class="w-full bg-red-400 sm:hidden"
+            variant="primary"
+            size="md"
+            href=""
+        >
+            Delete
+        </x-button>
+        <x-button
+            class="w-full sm:hidden"
+            variant="secondary"
+            size="md"
+            href=""
+        >
+            Edit
+        </x-button>
+    </div>
     <x-modal.base
         name="create-review"
         :show="$errors->createReview->isNotEmpty() || $errors->createReviewValidation->isNotEmpty()"

--- a/resources/views/movie.blade.php
+++ b/resources/views/movie.blade.php
@@ -50,24 +50,26 @@
         >
             Add to list
         </x-button>
-        <div class="mt-2 flex gap-2 sm:hidden">
-            <x-button
-                class="w-full bg-red-400 sm:hidden"
-                variant="primary"
-                size="md"
-                href=""
-            >
-                Delete
-            </x-button>
-            <x-button
-                class="w-full sm:hidden"
-                variant="secondary"
-                size="md"
-                href=""
-            >
-                Edit
-            </x-button>
-        </div>
+        @if ($isAdmin)
+            <div class="mt-2 flex gap-2 sm:hidden">
+                <x-button
+                    class="w-full bg-red-400 sm:hidden"
+                    variant="primary"
+                    size="md"
+                    href=""
+                >
+                    Delete
+                </x-button>
+                <x-button
+                    class="w-full sm:hidden"
+                    variant="secondary"
+                    size="md"
+                    href=""
+                >
+                    Edit
+                </x-button>
+            </div>
+        @endif
     </div>
 
     <!-- Desktop View -->
@@ -76,22 +78,24 @@
             <h1 class="w-150 text-2xl font-bold text-slate-50">
                 {!! $movie->title !!}
             </h1>
-            <div class="flex gap-2">
-                <x-button
-                    class="bg-red-400 hover:bg-red-500"
-                    variant="primary"
-                    size="md"
-                    href=""
-                >
-                    Delete
-                </x-button>
-                <x-button class="" variant="secondary" size="md" href="">
-                    Edit
-                </x-button>
-            </div>
+            @if ($isAdmin)
+                <div class="flex gap-2">
+                    <x-button
+                        class="bg-red-400 hover:bg-red-500"
+                        variant="primary"
+                        size="md"
+                        href=""
+                    >
+                        Delete
+                    </x-button>
+                    <x-button class="" variant="secondary" size="md" href="">
+                        Edit
+                    </x-button>
+                </div>
+            @endif
         </div>
 
-        <div class="flex items-center gap-2">
+        <div class="flex items-center gap-2 pt-3">
             <x-rating size="sm" :rating="$movie->rating_average" />
             <div class="text-indigo-200">|</div>
             <p>{!! $movie->year !!}</p>

--- a/resources/views/movie.blade.php
+++ b/resources/views/movie.blade.php
@@ -9,7 +9,7 @@
         <div class="flex justify-between pt-4 sm:hidden">
             <div class="flex flex-col gap-4 sm:hidden">
                 <h1 class="text-2xl font-bold text-slate-50 sm:hidden">
-                    {{ $movie->title }}
+                    {!! $movie->title !!}
                 </h1>
                 <div class="flex flex-col gap-1 sm:hidden">
                     <div class="flex items-center gap-2 sm:hidden">
@@ -19,12 +19,14 @@
                             :rating="$movie->rating_average"
                         />
                         <div class="text-indigo-200 sm:hidden">|</div>
-                        <p>{{ $movie->year }}</p>
+                        <p>{!! $movie->year !!}</p>
                         <div class="text-indigo-200 sm:hidden">|</div>
-                        <p class="sm:hidden">{{ $movie->duration }}</p>
+                        <p class="sm:hidden">
+                            {!! formatDuration($movie->duration) !!}
+                        </p>
                     </div>
                     <p class="text-xs font-bold text-slate-100 sm:hidden">
-                        {{ $movie->director }}
+                        {!! $movie->director !!}
                     </p>
                 </div>
                 <div class="flex flex-wrap gap-2 sm:hidden">
@@ -39,30 +41,7 @@
                 alt="Poster of {{ $movie->title }}"
             />
         </div>
-        <x-poster class="w-32 sm:hidden" src="{{ $movie->poster }}" />
-    </div>
-    <div
-        class="flex flex-col gap-3 sm:hidden"
-        x-data="{ showFullText: false }"
-    >
-        <p :class="{ 'line-clamp-3': !showFullText }" class="pt-3 sm:hidden">
-            {{ $movie->description }}
-        </p>
-        <button
-            @click="showFullText = !showFullText"
-            class="cursor-pointer text-end text-sm font-bold text-indigo-400 hover:underline focus:outline-none sm:hidden"
-        >
-            <span x-show="!showFullText">Show more</span>
-            <span x-show="showFullText">Show less</span>
-        </button>
-    </div>
-
-    <x-button class="mt-6 w-full sm:hidden" variant="primary" size="md" href="">
-        Add to list
-    </x-button>
-
-    <div class="mt-2 flex gap-2 sm:hidden">
-        <p class="pt-3 sm:hidden">{{ $movie->description }}</p>
+        <p class="pt-3 sm:hidden">{!! $movie->description !!}</p>
         <x-button
             class="mt-6 w-full sm:hidden"
             variant="primary"
@@ -93,9 +72,9 @@
 
     <!-- Desktop View -->
     <div class="hidden px-4 sm:block">
-        <div class="flex items-center justify-between">
-            <h1 class="text-2xl font-bold text-slate-50">
-                {{ $movie->title }}
+        <div class="flex items-center justify-between gap-4">
+            <h1 class="w-150 text-2xl font-bold text-slate-50">
+                {!! $movie->title !!}
             </h1>
             <div class="flex gap-2">
                 <x-button
@@ -111,15 +90,16 @@
                 </x-button>
             </div>
         </div>
+
         <div class="flex items-center gap-2">
             <x-rating size="sm" :rating="$movie->rating_average" />
             <div class="text-indigo-200">|</div>
-            <p>{{ $movie->year }}</p>
+            <p>{!! $movie->year !!}</p>
             <div class="text-indigo-200">|</div>
-            <p class="">{{ $movie->duration }}</p>
+            <p class="">{!! formatDuration($movie->duration) !!}</p>
             <div class="text-indigo-200">|</div>
             <p class="text-xs font-bold text-slate-100">
-                {{ $movie->director }}
+                {!! $movie->director !!}
             </p>
         </div>
 
@@ -148,7 +128,7 @@
             </div>
         </div>
         <p class="max-w-144 pt-3">
-            {{ $movie->description }}
+            {!! $movie->description !!}
         </p>
     </div>
     <x-button


### PR DESCRIPTION
## This PR includes the information section for a movie
- Fixed the ReviewsFactory to only use existing movies when generating reviews
- The delete and edit buttons are only visible for admin users

Note: Because of a tricky design, where the mobile and desktop designs differs a lot, I decided to make 1 version for mobile, and 1 version for desktop. Because of that there is a lot of duplicate code (which is not optional). If there is time later, I will fix it, but for now its important to get this in main.

I also decided to not include the "Show more" button to show more text for now because it is not prioritized. That will also be added if there is time.

<img width="1325" alt="Skärmavbild 2025-02-13 kl  17 27 51" src="https://github.com/user-attachments/assets/36bcf1b9-28e1-43aa-bebd-17d59b60002b" />
<img width="319" alt="Skärmavbild 2025-02-13 kl  17 28 17" src="https://github.com/user-attachments/assets/1a2d49a3-5c8f-40a3-a56b-a36b0f508512" />

closes #130 

