### PR TITLE
feat: profile menu

### DIFF
--- a/app/Http/Controllers/ProfileController.php
+++ b/app/Http/Controllers/ProfileController.php
@@ -4,6 +4,7 @@ namespace App\Http\Controllers;
 
 use App\Http\Requests\ProfileUpdateRequest;
 use App\Models\User;
+use Exception;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Auth;
@@ -101,5 +102,26 @@ class ProfileController extends Controller
         $request->session()->regenerateToken();
 
         return Redirect::to('/');
+    }
+
+    public function makeAdmin($id): RedirectResponse
+    {
+        try {
+            $user = User::findOrFail($id);
+            $currentUser = Auth::user();
+
+            if ($currentUser->role !== 'admin') {
+                throw new Exception('You are not allowed to make this user an admin');
+            }
+
+            $user->role = 'admin';
+            $user->save();
+
+            return redirect()->back();
+        } catch (Exception) {
+            return redirect()
+                ->back()
+                ->withErrors('Something went wrong when making this user an admin!', 'makeAdmin');
+        }
     }
 }

--- a/resources/views/components/profile.blade.php
+++ b/resources/views/components/profile.blade.php
@@ -5,7 +5,7 @@
 
 <div class="relative flex w-full">
     <div
-        class="mr-8 flex w-full flex-col gap-4 md:flex-row md:items-center md:justify-between"
+        class="mr-10 flex w-full flex-col gap-4 md:flex-row md:items-center md:justify-between"
     >
         <div class="flex items-center gap-4">
             <x-avatar :image="$user->image" size="lg" />
@@ -36,7 +36,13 @@
         @endisset
     </div>
 
-    <div class="absolute top-0 right-0">
+    <x-button
+        x-data
+        @click="$dispatch('open-modal', 'profile-menu')"
+        variant="icon"
+        srLabel="Open profile menu"
+        class="absolute top-0 right-0"
+    >
         <x-lucide-ellipsis-vertical class="size-6 text-slate-50" />
-    </div>
+    </x-button>
 </div>

--- a/resources/views/profile.blade.php
+++ b/resources/views/profile.blade.php
@@ -73,11 +73,8 @@
         </div>
     @endif
 
-    <x-modal.base
-        name="profile-menu"
-        :show="$errors->edit->isNotEmpty() || $errors->editListValidation->isNotEmpty()"
-    >
-        <x-modal.menu>
+    <x-modal.base name="profile-menu" :show="$errors->makeAdmin->isNotEmpty()">
+        <x-modal.menu :error="$errors->makeAdmin->first()">
             <x-slot:title>
                 {{ $user->username }}
             </x-slot>
@@ -97,7 +94,7 @@
                 </form>
                 <x-modal.divider />
 
-                {{-- TODO: add delete account functionality --}}
+                {{-- TODO: open delete account confirm with password modal --}}
                 <x-menu-item variant="destructive">Delete account</x-menu-item>
                 <x-modal.divider />
             @else
@@ -110,23 +107,17 @@
                     <x-menu-item>Ban user</x-menu-item>
                     <x-modal.divider />
 
-                    {{-- TODO: make admin functionality --}}
-                    <x-menu-item>Make admin</x-menu-item>
+                    <form
+                        method="post"
+                        action="{{ route('admin.profile.make-admin', ['id' => $user->id]) }}"
+                    >
+                        @csrf
+                        @method('put')
+                        <x-menu-item>Make admin</x-menu-item>
+                    </form>
                     <x-modal.divider />
                 @endif
             @endif
-
-            {{--
-                <form
-                method="post"
-                action="{{ route('list.destroy', ['id' => $list->id]) }}"
-                >
-                @csrf
-                @method('delete')
-                <x-menu-item variant="destructive">Delete list</x-menu-item>
-                </form>
-                <x-modal.divider />
-            --}}
 
             <x-menu-item
                 x-data

--- a/resources/views/profile.blade.php
+++ b/resources/views/profile.blade.php
@@ -87,12 +87,14 @@
                 <x-menu-item>Edit profile</x-menu-item>
                 <x-modal.divider />
 
-                {{-- TODO: add log out functionality --}}
-                <x-menu-item>Log out</x-menu-item>
-                <x-modal.divider />
-
                 {{-- TODO: add change password functionality --}}
                 <x-menu-item>Change password</x-menu-item>
+                <x-modal.divider />
+
+                <form method="post" action="{{ route('logout') }}">
+                    @csrf
+                    <x-menu-item>Log out</x-menu-item>
+                </form>
                 <x-modal.divider />
 
                 {{-- TODO: add delete account functionality --}}

--- a/resources/views/profile.blade.php
+++ b/resources/views/profile.blade.php
@@ -72,4 +72,67 @@
             @endif
         </div>
     @endif
+
+    <x-modal.base
+        name="profile-menu"
+        :show="$errors->edit->isNotEmpty() || $errors->editListValidation->isNotEmpty()"
+    >
+        <x-modal.menu>
+            <x-slot:title>
+                {{ $user->username }}
+            </x-slot>
+
+            @if ($isCurrentUserProfile)
+                {{-- TODO: add edit profile modal --}}
+                <x-menu-item>Edit profile</x-menu-item>
+                <x-modal.divider />
+
+                {{-- TODO: add log out functionality --}}
+                <x-menu-item>Log out</x-menu-item>
+                <x-modal.divider />
+
+                {{-- TODO: add change password functionality --}}
+                <x-menu-item>Change password</x-menu-item>
+                <x-modal.divider />
+
+                {{-- TODO: add delete account functionality --}}
+                <x-menu-item variant="destructive">Delete account</x-menu-item>
+                <x-modal.divider />
+            @else
+                {{-- TODO: open report user modal --}}
+                <x-menu-item>Report user</x-menu-item>
+                <x-modal.divider />
+
+                @if (auth()->check() && auth()->user()->role === 'admin' && $user->role !== 'admin')
+                    {{-- TODO: open ban user modal --}}
+                    <x-menu-item>Ban user</x-menu-item>
+                    <x-modal.divider />
+
+                    {{-- TODO: make admin functionality --}}
+                    <x-menu-item>Make admin</x-menu-item>
+                    <x-modal.divider />
+                @endif
+            @endif
+
+            {{--
+                <form
+                method="post"
+                action="{{ route('list.destroy', ['id' => $list->id]) }}"
+                >
+                @csrf
+                @method('delete')
+                <x-menu-item variant="destructive">Delete list</x-menu-item>
+                </form>
+                <x-modal.divider />
+            --}}
+
+            <x-menu-item
+                x-data
+                @click="$dispatch('close-modal', 'profile-menu')"
+                variant="highlights"
+            >
+                Cancel
+            </x-menu-item>
+        </x-modal.menu>
+    </x-modal.base>
 </x-layout>

--- a/routes/web.php
+++ b/routes/web.php
@@ -36,6 +36,7 @@ Route::middleware(['auth', AdminMiddleware::class])->prefix('/admin')->group(fun
     Route::get('/create-user', fn () => view('admin.create-user'))->name('admin.create.user');
     Route::get('/users', fn () => view('admin.users'))->name('admin.users');
     Route::get('/featured', fn () => view('admin.featured-lists'))->name('admin.featured');
+    Route::put('/make-admin/{id}', [ProfileController::class, 'makeAdmin'])->name('admin.profile.make-admin');
 
     Route::controller(ReviewController::class)->prefix('/reports')->group(function () {
         Route::get('/users', 'index')->name('reports.user');


### PR DESCRIPTION
closes #103

- profile menu that displays different menu items depending on
  - if the current user is an admin
  - if you are on your own profile
- functionality for logging out
- functionality for making a user an admin

### preview
<img width="1552" alt="image" src="https://github.com/user-attachments/assets/b757c06b-518d-489f-b9a2-67356093bbb2" />
<img width="1552" alt="image" src="https://github.com/user-attachments/assets/056b8596-8ed3-4a22-ad03-378a00cdf32e" />

### test
- go to your own profile
  - try logging out
- ensure you're an admin
- go to someone else's profile who's not an admin
  - make them an admin