### PR TITLE
feat: report review

### DIFF
--- a/app/Http/Controllers/ReportController.php
+++ b/app/Http/Controllers/ReportController.php
@@ -3,6 +3,7 @@
 namespace App\Http\Controllers;
 
 use App\Models\Report;
+use Exception;
 use Illuminate\Http\Request;
 
 class ReportController extends Controller
@@ -26,9 +27,25 @@ class ReportController extends Controller
     /**
      * Store a newly created resource in storage.
      */
-    public function store(Request $request)
+    public function store(Request $request, $id)
     {
-        //
+        $request->validateWithBag('createReportValidation', [
+            'reason' => ['required', 'string', 'max:255'],
+        ]);
+
+        try {
+            Report::create([
+                'reason' => $request->reason,
+                'review_id' => $id,
+            ]);
+
+            return redirect(url()->previous());
+        } catch (Exception) {
+            return redirect()
+                ->back()
+                ->withInput()
+                ->withErrors('Something went wrong when creating the report!', 'createReport');
+        }
     }
 
     /**

--- a/resources/views/review.blade.php
+++ b/resources/views/review.blade.php
@@ -83,8 +83,15 @@
             </x-slot>
 
             @if (! $isAuthor)
-                {{-- TODO: open report review modal --}}
-                <x-menu-item>Report</x-menu-item>
+                <x-menu-item
+                    x-data
+                    @click="
+                        $dispatch('close-modal', 'review-menu')
+                        $dispatch('open-modal', 'report-review-modal')
+                    "
+                >
+                    Report
+                </x-menu-item>
                 <x-modal.divider />
             @endif
 
@@ -169,6 +176,117 @@
                         Cancel
                     </x-button>
                     <x-button class="flex-1">Update review</x-button>
+                </div>
+            </form>
+        </x-modal.input>
+    </x-modal.base>
+
+    <x-modal.base
+        name="update-review"
+        :show="$errors->updateReview->isNotEmpty() || $errors->updateReviewValidation->isNotEmpty()"
+    >
+        <x-modal.input>
+            <x-slot:title>
+                {{ $review->movie->title }}
+            </x-slot>
+            <form
+                method="post"
+                action="{{ route('review.update', ['id' => $review->id]) }}"
+                class="flex flex-col gap-6"
+            >
+                @csrf
+                @method('put')
+
+                <div class="flex flex-col gap-4">
+                    <x-input.rating
+                        name="rating"
+                        :value="old('rating') ? old('rating') : $review->rating"
+                        required
+                        :error="$errors->updateReviewValidation->first('rating')"
+                        label="Your rating"
+                    />
+                    <x-input.textarea
+                        name="content"
+                        :value="old('content') ? old('content') : $review->content"
+                        :error="$errors->updateReviewValidation->first('content')"
+                        label="Review"
+                        placeholder="Let others know why they should (or shouldn't) watch this film."
+                        color="light"
+                    />
+                </div>
+
+                <x-input.error :message="$errors->updateReview->first()" />
+
+                <div class="flex gap-2">
+                    <x-button
+                        x-data
+                        @click="$dispatch('close-modal', 'update-review')"
+                        type="button"
+                        variant="secondary"
+                    >
+                        Cancel
+                    </x-button>
+                    <x-button class="flex-1">Update review</x-button>
+                </div>
+            </form>
+        </x-modal.input>
+    </x-modal.base>
+
+    <x-modal.base
+        name="report-review-modal"
+        :show="$errors->createReport->isNotEmpty() || $errors->createReportValidation->isNotEmpty()"
+    >
+        <x-modal.input>
+            <x-slot:title>
+                @if ($isAuthor)
+                    <p class="font-normal">
+                        Review of
+                        <span class="font-bold">
+                            {{ $review->movie->title }}
+                        </span>
+                    </p>
+                @else
+                    <p class="font-normal">
+                        <span class="font-bold">
+                            {{ $review->user->username }}'s
+                        </span>
+                        review of
+                        <span class="font-bold">
+                            {{ $review->movie->title }}
+                        </span>
+                    </p>
+                @endif
+            </x-slot>
+
+            <form
+                method="post"
+                action="{{ route('report.store.review', ['id' => $review->id]) }}"
+                class="flex flex-col gap-6"
+            >
+                @csrf
+                <div class="flex flex-col gap-4">
+                    <x-input.textarea
+                        name="reason"
+                        :value="old('reason')"
+                        :error="$errors->createReportValidation->first('reason')"
+                        label="Why do you want to report this review?"
+                        placeholder="Describe how this review breaks our rules"
+                        color="light"
+                    />
+                </div>
+
+                <x-input.error :message="$errors->createReport->first()" />
+
+                <div class="flex gap-2">
+                    <x-button
+                        x-data
+                        @click="$dispatch('close-modal', 'create-list')"
+                        type="button"
+                        variant="secondary"
+                    >
+                        Cancel
+                    </x-button>
+                    <x-button class="flex-1">Send</x-button>
                 </div>
             </form>
         </x-modal.input>

--- a/resources/views/review.blade.php
+++ b/resources/views/review.blade.php
@@ -280,7 +280,7 @@
                 <div class="flex gap-2">
                     <x-button
                         x-data
-                        @click="$dispatch('close-modal', 'create-list')"
+                        @click="$dispatch('close-modal', 'report-review-modal')"
                         type="button"
                         variant="secondary"
                     >

--- a/routes/web.php
+++ b/routes/web.php
@@ -3,6 +3,7 @@
 use App\Http\Controllers\ListController;
 use App\Http\Controllers\MovieController;
 use App\Http\Controllers\ProfileController;
+use App\Http\Controllers\ReportController;
 use App\Http\Controllers\ReviewController;
 use App\Http\Middleware\AdminMiddleware;
 use Illuminate\Support\Facades\Route;
@@ -30,6 +31,10 @@ Route::controller(ReviewController::class)->group(function () {
     Route::post('/m/{id}/{title}', 'store')->middleware(['auth'])->name('review.store');
     Route::delete('/review/{id}', 'destroy')->middleware(['auth'])->name('review.destroy');
     Route::put('/review/{id}', 'update')->middleware(['auth'])->name('review.update');
+});
+
+Route::controller(ReportController::class)->group(function () {
+    Route::post('/review/{id}', 'store')->middleware(['auth'])->name('report.store.review');
 });
 
 Route::middleware(['auth', AdminMiddleware::class])->prefix('/admin')->group(function () {


### PR DESCRIPTION
closes #111 

- open report review modal and close the review menu
- `store` function in `ReportController`
- route for report review
- modal with form and error handling

### preview
<img width="1552" alt="image" src="https://github.com/user-attachments/assets/3349b9f7-1bac-45c7-8f28-5554eaa34b49" />

### test
- go to a review page
- click the menu
- click report review
- write a report longer than 255 characters and send (you must be logged in)
- you should see an error message
- write a shorter report and send
- you should be sent back to the review page