### PR TITLE
feat: disallow banned users from logging in

### DIFF
--- a/app/Http/Requests/Auth/LoginRequest.php
+++ b/app/Http/Requests/Auth/LoginRequest.php
@@ -2,6 +2,7 @@
 
 namespace App\Http\Requests\Auth;
 
+use Carbon\Carbon;
 use Illuminate\Auth\Events\Lockout;
 use Illuminate\Foundation\Http\FormRequest;
 use Illuminate\Support\Facades\Auth;
@@ -46,6 +47,16 @@ class LoginRequest extends FormRequest
 
             throw ValidationException::withMessages([
                 'credentials' => 'The provided credentials are not valid.',
+            ]);
+        }
+
+        $user = Auth::user();
+
+        if ($user->isBanned()) {
+            Auth::logout();
+
+            throw ValidationException::withMessages([
+                'banned' => 'Your account is banned until '.Carbon::parse($user->banned_until)->format('F jS').'.',
             ]);
         }
 

--- a/database/migrations/0001_01_01_000000_create_users_table.php
+++ b/database/migrations/0001_01_01_000000_create_users_table.php
@@ -18,7 +18,7 @@ return new class extends Migration
             $table->string('password');
             $table->string('image')->nullable();
             $table->enum('role', ['user', 'admin']);
-            $table->dateTime('banned_until')->nullable();
+            $table->date('banned_until')->nullable();
             $table->integer('banned_total')->default(0);
             $table->timestamp('email_verified_at')->nullable();
             $table->rememberToken();

--- a/resources/views/auth/log-in.blade.php
+++ b/resources/views/auth/log-in.blade.php
@@ -35,7 +35,7 @@
             />
 
             @if (! $errors->isEmpty())
-                <x-input.error message="{{ $errors->first('credentials') }}" />
+                <x-input.error message="{{ $errors->first() }}" />
             @endif
         </div>
 


### PR DESCRIPTION
closes #409 

- a banned user will be blocked from logging in
- an error message will be displayed saying how long they are blocked for

### preview
https://github.com/user-attachments/assets/e4af8d16-9139-43c6-be90-26d6dbb6df35

### testing
- log in with an unbanned account
- ensure it still works
- log out
- ban yourself
- try logging in again
- you should see the error message