### PR TITLE
fix: reports check

### DIFF
--- a/database/factories/ReportFactory.php
+++ b/database/factories/ReportFactory.php
@@ -23,10 +23,14 @@ class ReportFactory extends Factory
      */
     public function definition(): array
     {
+        $isReviewReport = $this->faker->boolean;
+        $reviewId = $isReviewReport ? Review::all()->random()->id : null;
+        $userId = ! $isReviewReport ? User::all()->random()->id : null;
+
         return [
-            'review_id' => Review::factory(),
             'reason' => $this->faker->realText(rand(50, 255)),
-            'user_id' => User::factory(),
+            'review_id' => $reviewId,
+            'user_id' => $userId,
         ];
     }
 }

--- a/database/migrations/2025_01_30_122917_create_reports_table.php
+++ b/database/migrations/2025_01_30_122917_create_reports_table.php
@@ -4,6 +4,7 @@ use App\Models\Review;
 use App\Models\User;
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Schema;
 
 class CreateReportsTable extends Migration
@@ -27,6 +28,10 @@ class CreateReportsTable extends Migration
                 ->onDelete('cascade');
             $table->timestamps();
         });
+
+        DB::statement('ALTER TABLE reports ADD CONSTRAINT check_user_or_review CHECK (
+            (user_id IS NOT NULL AND review_id IS NULL) OR (user_id IS NULL AND review_id IS NOT NULL)
+        )');
     }
 
     /**


### PR DESCRIPTION
currently you can set both a `review_id` and a `user_id` of a report at the same time. this is not how we intended the table to be used. so i've added a `CHECK` that ensures only one of the ids are set, not both and not neither. i also updated the factory accordingly

### before
<img width="1552" alt="image" src="https://github.com/user-attachments/assets/33c261a4-3fb0-41d3-882d-4b55b7d9269a" />

### after
<img width="1552" alt="image" src="https://github.com/user-attachments/assets/835aeeca-f1ab-4d39-803b-bb83c93a650e" />
