### PR TITLE
fix: previous url

### DIFF
--- a/app/Http/Controllers/ReportController.php
+++ b/app/Http/Controllers/ReportController.php
@@ -45,7 +45,7 @@ class ReportController extends Controller
                 'user_id' => $userId,
             ]);
 
-            return redirect(url()->previous());
+            return redirect()->back();
         } catch (Exception) {
             return redirect()
                 ->back()

--- a/app/Http/Controllers/ReviewController.php
+++ b/app/Http/Controllers/ReviewController.php
@@ -7,6 +7,7 @@ use App\Models\User;
 use Exception;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Str;
 
 class ReviewController extends Controller
 {
@@ -63,7 +64,12 @@ class ReviewController extends Controller
         $review = Review::with(['user', 'movie'])->findOrFail($id);
         $isAuthor = Auth::check() && $review->isWrittenBy(Auth::user());
 
-        return view('review', ['review' => $review, 'isAuthor' => $isAuthor]);
+        $previousUrl = url()->previous();
+        $backLink = Str::contains($previousUrl, ['/m/', '/u/'])
+            ? $previousUrl
+            : route('movie', ['id' => $review->movie->id, 'title' => $review->movie->title]);
+
+        return view('review', ['review' => $review, 'isAuthor' => $isAuthor, 'backLink' => $backLink]);
     }
 
     /**

--- a/resources/views/review.blade.php
+++ b/resources/views/review.blade.php
@@ -1,7 +1,6 @@
 @php
     $formattedDate = formatDate($review->created_at);
     $backLabel = request('from') === 'movie' ? 'Back to movie' : (request('from') === 'profile' ? 'Back to profile' : 'Back');
-    $backHref = url()->previous();
 @endphp
 
 <x-layout class="pt-1 sm:pt-10">
@@ -9,7 +8,7 @@
         <x-section-header.back-link
             :title="$review->movie->title"
             extraLabel="Review"
-            href="{{ $backHref }}"
+            href="{{ $backLink }}"
             backLabel="{{ $backLabel }}"
         />
         <x-button


### PR DESCRIPTION
closes #435 

- fix the `backLink` in reviews to fallback to going to the movie page if it can no longer determine the correct previous url (eg. if you edit the review)
- it will take you either back to your profile or to the movie page